### PR TITLE
Relieve constraints over subsets

### DIFF
--- a/Sources/Structure/Subsets.swift
+++ b/Sources/Structure/Subsets.swift
@@ -10,7 +10,7 @@ extension Collection {
 
     // MARK: - Subsets
 
-    /// - returns: All combinations of with a given cardinality
+    /// - Returns: All combinations of with a given cardinality
     /// (how many elements chosen per combination).
     public func subsets(cardinality k: Int) -> [[Element]] {
 

--- a/Sources/Structure/Subsets.swift
+++ b/Sources/Structure/Subsets.swift
@@ -6,7 +6,7 @@
 //
 //
 
-extension Collection where Index == Int, IndexDistance == Int {
+extension Collection {
 
     // MARK: - Subsets
 
@@ -14,36 +14,20 @@ extension Collection where Index == Int, IndexDistance == Int {
     /// (how many elements chosen per combination).
     public func subsets(cardinality k: Int) -> [[Element]] {
 
-        func subsets(
-            cardinality k: Int,
-            combinedWith prefix: [Element],
-            startingAt index: Int
-        ) -> [[Element]]
+        func subsets(cardinality k: Int, appendingTo prefix: [Element], at index: Int)
+            -> [[Element]]
         {
-
-            guard k > 0 else {
-                return [prefix]
-            }
-
+            guard k > 0 else { return [prefix] }
             if index < count {
-                let first = self[index]
+                let idx = index as! Index
                 return (
-                    subsets(
-                        cardinality: k - 1,
-                        combinedWith: prefix + [first],
-                        startingAt: index + 1
-                    ) +
-                    subsets(
-                        cardinality: k,
-                        combinedWith: prefix,
-                        startingAt: index + 1
-                    )
+                    subsets(cardinality: k - 1, appendingTo: prefix + [self[idx]], at: index + 1) +
+                    subsets(cardinality: k, appendingTo: prefix, at: index + 1)
                 )
             }
-
             return []
         }
 
-        return subsets(cardinality: k, combinedWith: [], startingAt: 0)
+        return subsets(cardinality: k, appendingTo: [], at: 0)
     }
 }

--- a/Sources/Structure/Subsets.swift
+++ b/Sources/Structure/Subsets.swift
@@ -14,20 +14,27 @@ extension Collection {
     /// (how many elements chosen per combination).
     public func subsets(cardinality k: Int) -> [[Element]] {
 
-        func subsets(cardinality k: Int, appendingTo prefix: [Element], at index: Int)
+        func subsets(cardinality k: Int, appendingTo prefix: [Element], at index: Index)
             -> [[Element]]
         {
             guard k > 0 else { return [prefix] }
-            if index < count {
-                let idx = index as! Index
+            if index < endIndex {
                 return (
-                    subsets(cardinality: k - 1, appendingTo: prefix + [self[idx]], at: index + 1) +
-                    subsets(cardinality: k, appendingTo: prefix, at: index + 1)
+                    subsets(
+                        cardinality: k - 1,
+                        appendingTo: prefix + [self[index]],
+                        at: indices.index(after: index)
+                    ) +
+                    subsets(
+                        cardinality: k,
+                        appendingTo: prefix,
+                        at: indices.index(after: index)
+                    )
                 )
             }
             return []
         }
 
-        return subsets(cardinality: k, appendingTo: [], at: 0)
+        return subsets(cardinality: k, appendingTo: [], at: startIndex)
     }
 }

--- a/Sources/Structure/Subsets.swift
+++ b/Sources/Structure/Subsets.swift
@@ -19,17 +19,10 @@ extension Collection {
         {
             guard k > 0 else { return [prefix] }
             if index < endIndex {
+                let next = indices.index(after: index)
                 return (
-                    subsets(
-                        cardinality: k - 1,
-                        appendingTo: prefix + [self[index]],
-                        at: indices.index(after: index)
-                    ) +
-                    subsets(
-                        cardinality: k,
-                        appendingTo: prefix,
-                        at: indices.index(after: index)
-                    )
+                    subsets(cardinality: k - 1, appendingTo: prefix + [self[index]], at: next) +
+                    subsets(cardinality: k, appendingTo: prefix, at: next)
                 )
             }
             return []

--- a/Tests/StructureTests/DestructureTests/SubsetsTests.swift
+++ b/Tests/StructureTests/DestructureTests/SubsetsTests.swift
@@ -33,10 +33,7 @@ class SubsetsTests: XCTestCase {
 
     func testSubsetsQuadruple() {
         let array = [1,2,3,4]
-        XCTAssert(
-            [[1,2],[1,3],[1,4],[2,3],[2,4],[3,4]] ==
-                array.subsets(cardinality: 2)
-        )
+        XCTAssert([[1,2],[1,3],[1,4],[2,3],[2,4],[3,4]] == array.subsets(cardinality: 2))
     }
 }
 


### PR DESCRIPTION
Currently, the `Index` and `IndexDistance` of the `Collection` over which `subsets` is implemented must be `Int`.

This PR relieves this constraint such that `Index` and `IndexDistance` can be of any appropriate type.