### PR TITLE
Make rotate(d) over more abstract Collection protocols

### DIFF
--- a/Sources/Structure/Rotate.swift
+++ b/Sources/Structure/Rotate.swift
@@ -15,7 +15,7 @@ extension MutableCollection where Self: BidirectionalCollection {
         return copy
     }
 
-    /// - Returns: Rotates the elements contained herein by the given `amount`.
+    /// Rotates the elements contained herein by the given `amount`.
     public mutating func rotate(by amount: IndexDistance) {
         guard amount != 0 else { return }
         let amount = (amount < 0 ? count + amount : amount) % count

--- a/Sources/Structure/Rotate.swift
+++ b/Sources/Structure/Rotate.swift
@@ -5,23 +5,27 @@
 //  Created by James Bean on 8/23/17.
 //
 
-extension Array {
+extension MutableCollection where Self: BidirectionalCollection {
 
-    public func rotated(by amount: Int) -> Array {
+    /// - Returns: A mutable and bidirectional collection with its elements rotated by the given
+    /// `amount`.
+    public func rotated(by amount: IndexDistance) -> Self {
         var copy = self
         copy.rotate(by: amount)
         return copy
     }
 
-    public mutating func rotate(by positions: Int) {
-        guard positions != 0 else { return }
-        let positions = (positions < 0 ? count + positions : positions) % count
-        reverse(in: 0 ..< positions - 1)
-        reverse(in: positions ..< count - 1)
-        reverse(in: 0 ..< count - 1)
+    /// - Returns: Rotates the elements contained herein by the given `amount`.
+    public mutating func rotate(by amount: IndexDistance) {
+        guard amount != 0 else { return }
+        let amount = (amount < 0 ? count + amount : amount) % count
+        let amountIndex = index(startIndex, offsetBy: amount)
+        reverse(in: startIndex ..< index(before: amountIndex))
+        reverse(in: amountIndex ..< index(before: endIndex))
+        reverse(in: startIndex ..< index(before: endIndex))
     }
 
-    private mutating func reverse(in range: CountableRange<Int>) {
+    private mutating func reverse(in range: Range<Index>) {
         guard count > 1 else { return }
         assert(range.lowerBound >= startIndex)
         assert(range.upperBound < endIndex)
@@ -29,8 +33,8 @@ extension Array {
         var end = range.upperBound
         while start < end, start != end {
             swapAt(start, end)
-            start += 1
-            end -= 1
+            start = index(after: start)
+            end = index(before: end)
         }
     }
 }


### PR DESCRIPTION
This PR implements `rotate(by:)` and `rotated(by:)` over `MutableCollection & BidirectionalCollection` rather than `Array`.