### PR TITLE
Make max an explicit argument label for random int

### DIFF
--- a/Tests/DestructurePerformanceTests/DestructurePerformanceTests.swift
+++ b/Tests/DestructurePerformanceTests/DestructurePerformanceTests.swift
@@ -12,14 +12,14 @@ import PerformanceTesting
 
 class DestructurePerformanceTests: PerformanceTestCase {
 
-    func randomInt(_ max: Int) -> Int {
+    func randomInt(max: Int) -> Int {
         return Int(arc4random_uniform(UInt32(max)))
     }
 
     func testDestructure() {
         assertPerformance(.constant) { testPoint in
             meanOutcome {
-                let array = Array(count: testPoint) { randomInt($0) }
+                let array = Array(count: testPoint) { randomInt(max: $0) }
                 return time {
                     let _ = array.destructured
                 }

--- a/Tests/StructurePerformanceTests/StableSortPerformanceTests.swift
+++ b/Tests/StructurePerformanceTests/StableSortPerformanceTests.swift
@@ -12,14 +12,14 @@ import PerformanceTesting
 
 class StableSortPerformanceTests: PerformanceTestCase {
 
-    func randomInt(_ max: Int) -> Int {
+    func randomInt(max: Int) -> Int {
         return Int(arc4random_uniform(UInt32(max)))
     }
 
     func testStableSort() {
         assertPerformance(.linear, testPoints: Scale.small) { testPoint in
             meanOutcome {
-                let array = Array(count: testPoint) { randomInt($0) }
+                let array = Array(count: testPoint) { randomInt(max: $0) }
                 return time {
                     _ = array.stableSort { $0 < $1 }
                 }


### PR DESCRIPTION
This PR just makes the `max` argument label required. Otherwise, the call site is a bit ambiguous.

We should definitely make the `Int` random number generator publicly available. Ultimately, I think it will be nice to bring in `Math` as a dependency :).