### PR TITLE
Refine implementation of isHomogeneous / isHeterogeneous, destructured

### DIFF
--- a/Sources/Destructure/Destructure.swift
+++ b/Sources/Destructure/Destructure.swift
@@ -8,22 +8,9 @@
 
 extension Collection {
 
-    // MARK: - List Processing
-
-    /// First `Element` of a list.
-    public var head: Element? {
-        return first
-    }
-
-    /// Remaining `Elements` of a list.
-    public var tail: SubSequence? {
-        guard !isEmpty else { return nil }
-        return dropFirst()
-    }
-
     /// 2-tuple containing the `head` `Element` and `tail` `[Element]` of `Self`
     public var destructured: (Element, SubSequence)? {
-        guard let head = head, let tail = tail else { return nil }
-        return (head, tail)
+        guard let first = first else { return nil }
+        return (first, dropFirst())
     }
 }

--- a/Sources/Structure/Predicates.swift
+++ b/Sources/Structure/Predicates.swift
@@ -49,11 +49,7 @@ extension Collection where Element: Equatable {
     /// `self` are logically equivalent.
     public var isHomogeneous: Bool {
         guard let (head,tail) = destructured else { return true }
-        for element in tail {
-            if element != head {
-                return false
-            }
-        }
+        for element in tail where element != head { return false }
         return true
     }
 
@@ -61,11 +57,7 @@ extension Collection where Element: Equatable {
     /// `self` are not logically equivalent.
     public var isHeterogeneous: Bool {
         guard let (head,tail) = destructured else { return false }
-        for element in tail {
-            if element == head {
-                return false
-            }
-        }
+        for element in tail where element == head { return false }
         return false
     }
 }

--- a/Sources/Structure/Predicates.swift
+++ b/Sources/Structure/Predicates.swift
@@ -6,6 +6,8 @@
 //
 //
 
+import Destructure
+
 extension Sequence {
 
     // MARK: - Predicates
@@ -41,37 +43,30 @@ extension Sequence {
     }
 }
 
-extension Sequence where Element: Equatable {
+extension Collection where Element: Equatable {
 
-    /// - returns: `true` if there are one or fewer elements in `self`, or if all elements in
+    /// - Returns: `true` if there are one or fewer elements in `self`, or if all elements in
     /// `self` are logically equivalent.
     public var isHomogeneous: Bool {
-
-        // FIXME: Use `destructured`
-
-        var initialElement: Element?
-
-        for element in self {
-
-            guard let elementToCompare = initialElement else {
-                initialElement = element
-                continue
-            }
-
-            if element != elementToCompare {
+        guard let (head,tail) = destructured else { return true }
+        for element in tail {
+            if element != head {
                 return false
             }
         }
-
         return true
     }
 
-
-    /// - returns: `false` if there are one or fewer elements in `self`, or if any elements in
+    /// - Returns: `false` if there are one or fewer elements in `self`, or if any elements in
     /// `self` are not logically equivalent.
     public var isHeterogeneous: Bool {
-        // FIXME: Use own implementation for quick exit upon new value
-        return !isHomogeneous
+        guard let (head,tail) = destructured else { return false }
+        for element in tail {
+            if element == head {
+                return false
+            }
+        }
+        return false
     }
 }
 

--- a/Tests/StructureTests/DestructureTests/ListProcessingTests.swift
+++ b/Tests/StructureTests/DestructureTests/ListProcessingTests.swift
@@ -12,22 +12,6 @@ import Restructure
 
 class ListProcessingTests: XCTestCase {
 
-    func testArraySliceHead() {
-        let arraySlice: ArraySlice = [1]
-        XCTAssertEqual(arraySlice.head, 1)
-    }
-
-    func testArraySliceTail() {
-        let arraySlice: ArraySlice<Int> = [1,2,3]
-        let tail = ArraySlice([2,3])
-        XCTAssertEqual(arraySlice.tail!, tail)
-    }
-
-    func testArraySliceTailNil() {
-        let arraySlice: ArraySlice<Int> = []
-        XCTAssertNil(arraySlice.tail)
-    }
-
     func testArraySliceDestructured() {
         let arraySlice: ArraySlice<Int> = [1,2,3]
         let (a,b) = arraySlice.destructured!
@@ -38,22 +22,6 @@ class ListProcessingTests: XCTestCase {
     func testArraySliceDestructuredNil() {
         let arraySlice: ArraySlice<Int> = []
         XCTAssertNil(arraySlice.destructured)
-    }
-
-    func testArrayHead() {
-        let array: Array = [1]
-        XCTAssertEqual(array.head, 1)
-    }
-
-    func testArrayTail() {
-        let array: Array<Int> = [1,2,3]
-        let tail: ArraySlice<Int> = [2,3]
-        XCTAssertEqual(array.tail!, tail)
-    }
-
-    func testArrayTailNil() {
-        let array: Array<Int> = []
-        XCTAssertNil(array.tail)
     }
 
     func testArrayDestructured() {


### PR DESCRIPTION
This PR:

- Removes `head` and `tail`, which are never actually used
- Refines the implementation of `Collection.destructured`
- Refines the implementation of `Collection.isHomogeneous` / `Collection.isHeterogeneous`