### PR TITLE
Make sure SumType sees Bitwise

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .target(name: "Structure", dependencies: ["Algebra", "Bitwise"]),
         .target(name: "DataStructures", dependencies: ["Algebra", "Restructure", "Destructure", "DictionaryProtocol", "StructureWrapping", "Structure", "Predicates", "SumType"]),
         .target(name: "Predicates", dependencies: ["Destructure"]),
-        .target(name: "Combinatorics"),
+        .target(name: "Combinatorics", dependencies: ["Destructure"]),
         .target(name: "SumType", dependencies: ["Bitwise"]),
 
         // Tests

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .target(name: "DataStructures", dependencies: ["Algebra", "Restructure", "Destructure", "DictionaryProtocol", "StructureWrapping", "Structure", "Predicates", "SumType"]),
         .target(name: "Predicates", dependencies: ["Destructure"]),
         .target(name: "Combinatorics"),
-        .target(name: "SumType"),
+        .target(name: "SumType", dependencies: ["Bitwise"]),
 
         // Tests
         .testTarget(name: "AlgebraTests", dependencies: ["Algebra"]),


### PR DESCRIPTION
This PR adds `Bitwise` as a dependency to `SumType`. This has been tripping up Travis CI (correctly), but wasn't doing so locally for me.

This should fix all of the other PRs on-deck.