### PR TITLE
Change IndexDistance to Int

### DIFF
--- a/Sources/Restructure/Rotate.swift
+++ b/Sources/Restructure/Rotate.swift
@@ -9,14 +9,14 @@ extension MutableCollection where Self: BidirectionalCollection {
 
     /// - Returns: A mutable and bidirectional collection with its elements rotated by the given
     /// `amount`.
-    public func rotated(by amount: IndexDistance) -> Self {
+    public func rotated(by amount: Int) -> Self {
         var copy = self
         copy.rotate(by: amount)
         return copy
     }
 
     /// Rotates the elements contained herein by the given `amount`.
-    public mutating func rotate(by amount: IndexDistance) {
+    public mutating func rotate(by amount: Int) {
         guard amount != 0 else { return }
         let amount = (amount < 0 ? count + amount : amount) % count
         let amountIndex = index(startIndex, offsetBy: amount)

--- a/Sources/Restructure/StableSort.swift
+++ b/Sources/Restructure/StableSort.swift
@@ -6,7 +6,7 @@
 //
 //
 
-extension RangeReplaceableCollection where Index == Int, IndexDistance == Int  {
+extension RangeReplaceableCollection where Index == Int  {
 
     public func stableSort(_ isOrderedBefore: @escaping (Element, Element) -> Bool) -> [Element] {
 

--- a/Sources/StructureWrapping/RandomAccessCollectionWrapping.swift
+++ b/Sources/StructureWrapping/RandomAccessCollectionWrapping.swift
@@ -63,7 +63,7 @@ extension RandomAccessCollectionWrapping {
     ///
     /// - Complexity: O(1)
     ///
-    public var count: Base.IndexDistance {
+    public var count: Int {
         return base.count
     }
 


### PR DESCRIPTION
Swift 4.1 simplifies collection indices a bit. A more concrete `Int` is used rather than `IndexDistance`.