### PR TITLE
Make InvertibleEnum.inverse customizable by specifying it in protocol

### DIFF
--- a/Sources/DataStructures/InvertibleEnum.swift
+++ b/Sources/DataStructures/InvertibleEnum.swift
@@ -5,9 +5,15 @@
 //  Created by James Bean on 5/17/18.
 //
 
-public protocol InvertibleEnum: CaseIterable, Equatable where Self.AllCases.Index == Int { }
+public protocol InvertibleEnum: CaseIterable, Equatable where Self.AllCases.Index == Int {
+
+    /// - Returns: Inverse of `self`.
+    var inverse: Self { get }
+}
 
 extension InvertibleEnum {
+
+    /// - Returns: Inverse of `self`.
     public var inverse: Self {
         let index = Self.allCases.index(of: self)!
         let inverseIndex = Self.allCases.count - 1 - index

--- a/Tests/DataStructuresTests/InvertibleEnumTests.swift
+++ b/Tests/DataStructuresTests/InvertibleEnumTests.swift
@@ -1,0 +1,41 @@
+//
+//  InvertibleEnumTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 5/18/18.
+//
+
+import XCTest
+import DataStructures
+
+class InvertibleEnumTests: XCTestCase {
+
+    enum OddCountEnum: InvertibleEnum {
+        case one
+        case two
+        case three
+        case four
+        case five
+    }
+
+    enum EvenCountEnum: InvertibleEnum {
+        case one
+        case two
+        case three
+        case four
+        case five
+        case six
+    }
+
+    func testOddCountInverse() {
+        let one = OddCountEnum.one
+        let expected = OddCountEnum.five
+        XCTAssertEqual(one.inverse, expected)
+    }
+
+    func testEventCountInverse() {
+        let one = EvenCountEnum.one
+        let expected = EvenCountEnum.six
+        XCTAssertEqual(one.inverse, expected)
+    }
+}


### PR DESCRIPTION
Some `InvertibleEnum` values may want to specify how the `inverse` is calculated. By explicitly listing `inverse` as part of the `InvertibleEnum` protocol declaration, it allows a downstream user to substitute an implementation.

For example, `(Absolute|Relative)NamedInterval` are both nice candidates for the `InvertibleEnum`, but the `inverse` of `unison` is not `seventh`, as would be the result with the current default implementation. The offset of the index within `allCases` needs to be bumped by one.