### PR TITLE
Let Swift derive Equatable conformance

### DIFF
--- a/Sources/DataStructures/CircularArray.swift
+++ b/Sources/DataStructures/CircularArray.swift
@@ -152,9 +152,7 @@ extension CircularArray: RangeReplaceableCollection {
     }
 }
 
-extension CircularArray: Equatable where Element: Equatable {
-    // MARK: - Equatable
-}
+extension CircularArray: Equatable where Element: Equatable { }
 
 extension CircularArray: ExpressibleByArrayLiteral {
 

--- a/Sources/DataStructures/DictionaryProtocol.swift
+++ b/Sources/DataStructures/DictionaryProtocol.swift
@@ -136,7 +136,4 @@ extension DictionaryProtocol where
     }
 }
 
-extension Dictionary: DictionaryProtocol {
-
-    // MARK: - `DictionaryProtocol`
-}
+extension Dictionary: DictionaryProtocol { }

--- a/Sources/DataStructures/Either.swift
+++ b/Sources/DataStructures/Either.swift
@@ -27,6 +27,4 @@ public enum Either <Left, Right> {
     }
 }
 
-extension Either: Equatable where Left: Equatable, Right: Equatable {
-    // MARK: - Equatable
-}
+extension Either: Equatable where Left: Equatable, Right: Equatable { }

--- a/Sources/DataStructures/LinkedList.swift
+++ b/Sources/DataStructures/LinkedList.swift
@@ -85,21 +85,7 @@ extension LinkedList: Collection {
     }
 }
 
-extension LinkedList: Equatable where Element: Equatable {
-
-    /// - returns: `true` if two `LinkedList` values are equivalent. Otherwise `false`.
-    public static func == (lhs: LinkedList, rhs: LinkedList) -> Bool {
-        switch (lhs, rhs) {
-        case (.end, .end):
-            return true
-        case let (.node(elementA, nextA), .node(elementB, nextB)):
-            return elementA == elementB && nextA == nextB
-        default:
-            return false
-        }
-    }
-
-}
+extension LinkedList: Equatable where Element: Equatable { }
 
 extension LinkedList: ExpressibleByArrayLiteral {
 

--- a/Sources/DataStructures/OrderedDictionary.swift
+++ b/Sources/DataStructures/OrderedDictionary.swift
@@ -111,33 +111,7 @@ extension OrderedDictionary: Collection {
     }
 }
 
-extension OrderedDictionary: Equatable where Value: Equatable {
-
-    /// - returns: `true` if all values contained in both `OrderedDictionary` values are
-    /// equivalent. Otherwise, `false`.
-    public static func == (lhs: OrderedDictionary, rhs: OrderedDictionary) -> Bool {
-
-        guard lhs.keys == rhs.keys else {
-            return false
-        }
-
-        for key in lhs.keys {
-
-            if rhs.values[key] == nil || rhs.values[key]! != lhs.values[key]! {
-                return false
-            }
-        }
-
-        for key in rhs.keys {
-
-            if lhs.values[key] == nil || lhs.values[key]! != rhs.values[key]! {
-                return false
-            }
-        }
-
-        return true
-    }
-}
+extension OrderedDictionary: Equatable where Value: Equatable { }
 
 extension OrderedDictionary: ExpressibleByDictionaryLiteral {
 

--- a/Sources/DataStructures/OrderedDictionary.swift
+++ b/Sources/DataStructures/OrderedDictionary.swift
@@ -153,11 +153,3 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
         }
     }
 }
-
-
-//public func == <K, V: Equatable> (lhs: OrderedDictionary<K,V>, rhs: OrderedDictionary<K,V>)
-//    -> Bool
-//{
-//
-//
-//}

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -14,6 +14,8 @@ public struct SortedArray <Element: Comparable>:
     SortedCollectionWrapping
 {
 
+    // MARK: - Instance Properties
+
     /// Underlying storage of elements contained herein.
     public var base: [Element] = []
 

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -78,21 +78,13 @@ public struct SortedArray <Element: Comparable>:
     }
 }
 
+extension SortedArray: Equatable { }
+
 extension SortedArray {
 
     /// - Returns: The slice of the `SortedArray` for the given `bounds`.
     public subscript(bounds: Range<Base.Index>) -> Slice<Base> {
         return Slice(base: base, bounds: bounds)
-    }
-}
-
-extension SortedArray: Equatable {
-
-    // MARK: - Equatable
-
-    /// - returns: `true` if all elements in both arrays are equivalent. Otherwise, `false`.
-    public static func == <T> (lhs: SortedArray<T>, rhs: SortedArray<T>) -> Bool {
-        return lhs.base == rhs.base
     }
 }
 

--- a/Sources/DataStructures/SortedDictionary.swift
+++ b/Sources/DataStructures/SortedDictionary.swift
@@ -74,6 +74,8 @@ public struct SortedDictionary<Key, Value>: DictionaryProtocol where Key: Hashab
     }
 }
 
+extension SortedDictionary: Equatable where Value: Equatable { }
+
 extension SortedDictionary: Collection {
 
     // MARK: - `Collection`
@@ -149,33 +151,6 @@ extension SortedDictionary: ExpressibleByDictionaryLiteral {
             insert(v, key: k)
         }
     }
-}
-
-/// - returns: `true` if all values contained in both `SortedDictionary` values are
-/// equivalent. Otherwise, `false`.
-public func == <K, V: Equatable> (lhs: SortedDictionary<K,V>, rhs: SortedDictionary<K,V>)
-    -> Bool
-{
-
-    guard lhs.keys == rhs.keys else {
-        return false
-    }
-
-    for key in lhs.keys {
-
-        if rhs.unsorted[key] == nil || rhs.unsorted[key]! != lhs.unsorted[key]! {
-            return false
-        }
-    }
-
-    for key in rhs.keys {
-
-        if lhs.unsorted[key] == nil || lhs.unsorted[key]! != rhs.unsorted[key]! {
-            return false
-        }
-    }
-
-    return true
 }
 
 /// - returns: `SortedOrderedDictionary` with values of two `SortedOrderedDictionary` values.

--- a/Sources/DataStructures/SortedDictionary.swift
+++ b/Sources/DataStructures/SortedDictionary.swift
@@ -78,7 +78,7 @@ extension SortedDictionary: Equatable where Value: Equatable { }
 
 extension SortedDictionary: Collection {
 
-    // MARK: - `Collection`
+    // MARK: - Collection
 
     /// Index after the given `index`.
     public func index(after index: Int) -> Int {
@@ -140,7 +140,7 @@ extension SortedDictionary {
 
 extension SortedDictionary: ExpressibleByDictionaryLiteral {
 
-    // MARK: - `ExpressibleByDictionaryLiteral`
+    // MARK: - ExpressibleByDictionaryLiteral
 
     /// Create a `SortedDictionary` with a `DictionaryLiteral`.
     public init(dictionaryLiteral elements: (Key, Value)...) {


### PR DESCRIPTION
This PR uses Swift 4.2's automatic deriving of `Equatable` conformance for `Equatable`-composed types.