### PR TITLE
Make Sum and Product types conform the protocols of their respective wrapped types

### DIFF
--- a/Sources/Algebra/Product.swift
+++ b/Sources/Algebra/Product.swift
@@ -7,13 +7,13 @@
 //
 
 /// Multiplicative monoidal view of a `Multiplicative`-conforming type.
-public struct Product <T: Multiplicative>: MonoidView {
+public struct Product <Value: Multiplicative>: MonoidView {
 
     // MARK: - Type Properties
 
     /// - Returns: The multiplicative identity wrapped in a `MultiplicativeMonoid`.
     public static var identity: Product {
-        return Product(T.one)
+        return Product(Value.one)
     }
 
     // MARK: - Type Methods
@@ -26,13 +26,28 @@ public struct Product <T: Multiplicative>: MonoidView {
     // MARK: - Instance Properties
 
     /// Value wrapped by `MultiplativeMonoid`.
-    public let value: T
+    public let value: Value
 
     // MARK: - Initializers
 
     /// Creates a `MultiplicativeMonoid` with the given `value.`
-    public init(_ value: T) {
+    public init(_ value: Value) {
         self.value = value
+    }
+}
+
+extension Product: Multiplicative {
+
+    // MARK: - Multiplicative
+
+    /// - Returns: The wrapped-up `one` type property of the wrapped type.
+    public static var one: Product<Value> {
+        return Product(Value.one)
+    }
+
+    /// - Returns: The wrapped-up product of the two given values.
+    public static func * (lhs: Product<Value>, rhs: Product<Value>) -> Product<Value> {
+        return Product(lhs.value * rhs.value)
     }
 }
 

--- a/Sources/Algebra/Sum.swift
+++ b/Sources/Algebra/Sum.swift
@@ -7,13 +7,13 @@
 //
 
 /// Additive monoidal view of a `Additive`-conforming type.
-public struct Sum <T: Additive>: MonoidView {
+public struct Sum <Value: Additive>: MonoidView {
 
     // MARK: - Type Properties
 
     /// - Returns: The additive identity wrapped in a `AdditiveMonoid`.
     public static var identity: Sum {
-        return Sum(T.zero)
+        return Sum(Value.zero)
     }
 
     // MARK: - Type Methods
@@ -26,13 +26,28 @@ public struct Sum <T: Additive>: MonoidView {
     // MARK: - Instance Properties
 
     /// Value wrapped by `AdditiveMonoid`.
-    public let value: T
+    public let value: Value
 
     // MARK: - Initializers
 
     /// Creates a `AdditiveMonoid` with the given `value.`
-    public init(_ value: T) {
+    public init(_ value: Value) {
         self.value = value
+    }
+}
+
+extension Sum: Additive {
+
+    // MARK: - Additive
+
+    /// - Returns: The wrapped-up `zero` type property of the wrapped type.
+    public static var zero: Sum<Value> {
+        return Sum(Value.zero)
+    }
+
+    /// - Returns: The wrapped-up sum of the two given values.
+    public static func + (lhs: Sum<Value>, rhs: Sum<Value>) -> Sum<Value> {
+        return Sum(lhs.value + rhs.value)
     }
 }
 

--- a/Sources/Algebra/Sum.swift
+++ b/Sources/Algebra/Sum.swift
@@ -6,7 +6,7 @@
 //
 //
 
-/// Multiplicative monoidal view of a `Additive`-conforming type.
+/// Additive monoidal view of a `Additive`-conforming type.
 public struct Sum <T: Additive>: MonoidView {
 
     // MARK: - Type Properties


### PR DESCRIPTION
The point of the `Sum` and `Product` types is to provide an `Additive` or `Multiplicative` view of a type which may conform to both protocols (e.g., `Int`, `Float`, `Double`, etc.). Currently, `Sum` and `Product` did not inherently conform to their respective `Additive` or `Multiplicative` protocols, making them somewhat useless.
