### PR TITLE
Reintroduce BinaryHeapPerformanceTests, reducing test point scale

### DIFF
--- a/Tests/DataStructuresPerformanceTests/BinaryHeapPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/BinaryHeapPerformanceTests.swift
@@ -13,25 +13,25 @@ class BinaryHeapPerformanceTests: XCTestCase {
 
     /// Guarantee that insertion into `BinaryHeap` is O(1).
     func testInsert_O_1() {
-        #warning("testInsert_0_1 is disabled because it takes too long. Reintroduce")
-//        let benchmark = Benchmark.mutating(
-//            setup: { BinaryHeap((0..<$0).map { _ in random }) },
-//            measuring: {
-//                let (element,value) = random
-//                _ = $0.insert(element,value)
-//            }
-//        )
-//        XCTAssert(benchmark.performance(is: .constant))
+        let benchmark = Benchmark.mutating(
+            testPoints: Scale.small,
+            setup: { BinaryHeap((0..<$0).map { _ in random }) },
+            measuring: {
+                let (element,value) = random
+                _ = $0.insert(element,value)
+            }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
     }
 
     /// Guarantee that popping the minimum value from `BinaryHeap` is O(1).
     func testPop_O_1() {
-        #warning("testPop_0_1 is disabled because it takes too long. Reintroduce")
-//        let benchmark = Benchmark.mutating(
-//            setup: { BinaryHeap((0..<$0).map { _ in random }) },
-//            measuring: { _ = $0.pop() }
-//        )
-//        XCTAssert(benchmark.performance(is: .constant))
+        let benchmark = Benchmark.mutating(
+            testPoints: Scale.small,
+            setup: { BinaryHeap((0..<$0).map { _ in random }) },
+            measuring: { _ = $0.pop() }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
     }
 }
 


### PR DESCRIPTION
This were taking quite a long time to run at the medium scale (`100...1_000_000`), as they are `mutating` benchmarks (which have to rebuild the `Subject` for each `Trial`). For now, testing up to a size of `1_000` should be ok to prove O(1)-ness.