### PR TITLE
Add (SortedArray|SortedDictionary).init(presorted:)

### DIFF
--- a/Sources/DataStructures/DictionaryProtocol.swift
+++ b/Sources/DataStructures/DictionaryProtocol.swift
@@ -38,10 +38,11 @@ extension DictionaryProtocol {
         zip(xs,ys).forEach { key, value in self[key] = value }
     }
 
-    /// Create a `DictionaryProtocol` with an array of tuples.
-    public init(_ keysAndValues: [(Key, Value)]) {
+    /// Create a `DictionaryProtocol`-conforming type with a collection with dictionary-like
+    /// elements.
+    public init <C: Collection> (_ collection: C) where C.Element == (key: Key, value: Value) {
         self.init()
-        for (key, value) in keysAndValues {
+        for (key, value) in collection {
             self[key] = value
         }
     }

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -32,7 +32,7 @@ public struct SortedArray <Element: Comparable>:
     /// Create a `SortedArray` with the given array of presorted elements.
     ///
     /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined lays ahead.
-    public init <S> (presorted: S) where S: Sequence, S.Element == Element {
+    public init <C> (presorted: C) where C: Collection, C.Element == Element {
         self.base = Array(presorted)
     }
 

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -31,7 +31,8 @@ public struct SortedArray <Element: Comparable>:
 
     /// Create a `SortedArray` with the given array of presorted elements.
     ///
-    /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined lays ahead.
+    /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined behavior is
+    /// certain.
     public init <C> (presorted: C) where C: Collection, C.Element == Element {
         self.base = Array(presorted)
     }

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -32,8 +32,8 @@ public struct SortedArray <Element: Comparable>:
     /// Create a `SortedArray` with the given array of presorted elements.
     ///
     /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined lays ahead.
-    public init(presorted: [Element]) {
-        self.base = presorted
+    public init <S> (presorted: S) where S: Sequence, S.Element == Element {
+        self.base = Array(presorted)
     }
 
     // MARK: - Instance Methods

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -26,7 +26,14 @@ public struct SortedArray <Element: Comparable>:
 
     /// Create a `SortedArray` with the given sequence of `elements`.
     public init <S> (_ elements: S) where S: Sequence, S.Element == Element {
-        self.base = Array(elements).sorted()
+        self.init(presorted: Array(elements).sorted())
+    }
+
+    /// Create a `SortedArray` with the given array of presorted elements.
+    ///
+    /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined lays ahead.
+    public init(presorted: [Element]) {
+        self.base = presorted
     }
 
     // MARK: - Instance Methods

--- a/Sources/DataStructures/SortedDictionary.swift
+++ b/Sources/DataStructures/SortedDictionary.swift
@@ -9,11 +9,6 @@
 /// Ordered dictionary which has sorted `keys`.
 public struct SortedDictionary<Key, Value>: DictionaryProtocol where Key: Hashable & Comparable {
 
-    /// Backing dictionary.
-    ///
-    // FIXME: Make `private` in Swift 4
-    internal var unsorted: [Key: Value] = [:]
-
     // MARK: - Instance Properties
 
     /// Values contained herein, in order sorted by their associated keys.
@@ -24,10 +19,24 @@ public struct SortedDictionary<Key, Value>: DictionaryProtocol where Key: Hashab
     /// Sorted keys.
     public var keys: SortedArray<Key> = []
 
+    /// Backing dictionary.
+    ///
+    // FIXME: Make `private` in Swift 4
+    internal var unsorted: [Key: Value] = [:]
+
     // MARK: - Initializers
 
     /// Create an empty `SortedOrderedDictionary`.
     public init() { }
+
+    /// Create a `SortedDictionary` with the elements of a presorted `OrderedDictionary`.
+    ///
+    /// - Warning: You must be certain that `presorted` is sorted, otherwise undefined behavior is
+    /// certain.
+    public init(presorted: OrderedDictionary<Key,Value>) {
+        self.keys = SortedArray(presorted: presorted.keys)
+        self.unsorted = Dictionary(presorted.map { $0 })
+    }
 
     // MARK: - Subscripts
 

--- a/Tests/DataStructuresTests/SortedArrayTests.swift
+++ b/Tests/DataStructuresTests/SortedArrayTests.swift
@@ -17,6 +17,12 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(sortedArray, [])
     }
 
+    func testInitWithPresorted() {
+        let array = (0...4).map { $0 }
+        let sortedArray = SortedArray(presorted: array)
+        XCTAssertEqual(sortedArray, [0,1,2,3,4])
+    }
+
     func testInitWithArraySorted() {
         let array = [1,5,4,3,2]
         let sortedArray = SortedArray(array)

--- a/Tests/DataStructuresTests/SortedDictionaryTests.swift
+++ b/Tests/DataStructuresTests/SortedDictionaryTests.swift
@@ -11,6 +11,12 @@ import DataStructures
 
 class SortedDictionaryTests: XCTestCase {
 
+    func testInitPresorted() {
+        let presorted: OrderedDictionary = [0: "zero", 1: "one", 2: "two", 3: "three"]
+        let sorted = SortedDictionary(presorted: presorted)
+        XCTAssertEqual(sorted, [0: "zero", 1: "one", 2: "two", 3: "three"])
+    }
+
     func testInsert() {
 
         var dict = SortedDictionary<Int, String>()


### PR DESCRIPTION
This PR adds the ability to initialize a `SortedArray` or `SortedDictionary` with presorted elements a less constrained `Collection` type.