### PR TITLE
Implement NewType

### DIFF
--- a/Sources/DataStructures/CircularArray.swift
+++ b/Sources/DataStructures/CircularArray.swift
@@ -15,7 +15,7 @@
 ///     loop[circular: 6] // => 0
 ///     loop[from: 2, through: 7] // => [2,3,4,5,0,1]
 ///
-public struct CircularArray<Element> {
+public struct CircularArray <Element> {
 
     private var storage: Array<Element>
 

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -10,3 +10,9 @@ public protocol NewType {
     var value: Value { get }
     init(value: Value)
 }
+
+extension NewType where Value: ExpressibleByIntegerLiteral {
+    init(integerLiteral value: Value.IntegerLiteralType) {
+        self.init(value: Value(integerLiteral: value))
+    }
+}

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -12,8 +12,14 @@ public protocol NewType {
 }
 
 extension NewType where Value: ExpressibleByIntegerLiteral {
-    init(integerLiteral value: Value.IntegerLiteralType) {
+    public init(integerLiteral value: Value.IntegerLiteralType) {
         self.init(value: Value(integerLiteral: value))
+    }
+}
+
+extension NewType where Value: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Value.FloatLiteralType) {
+        self.init(value: Value(floatLiteral: value))
     }
 }
 
@@ -52,3 +58,6 @@ extension NewType where Value: Numeric {
         self.init(value: value)
     }
 }
+
+extension NewType where Value: SignedNumeric { }
+

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -29,6 +29,16 @@ extension NewType where Value: ExpressibleByFloatLiteral {
     }
 }
 
+extension NewType where
+    Value: ExpressibleByArrayLiteral,
+    Value: RangeReplaceableCollection,
+    Value.ArrayLiteralElement == Value.Element
+{
+    public init(arrayLiteral values: Value.ArrayLiteralElement...) {
+        self.init(value: Value(values))
+    }
+}
+
 extension NewType where Value: Numeric {
 
     public var magnitude: Value.Magnitude {
@@ -70,5 +80,34 @@ extension NewType where Value: SignedNumeric { }
 extension NewType where Value: Sequence {
     public func makeIterator() -> Value.Iterator {
         return value.makeIterator()
+    }
+}
+
+extension NewType where Value: Collection {
+
+    public typealias Iterator = Value.Iterator
+
+    /// Start index.
+    public var startIndex: Value.Index {
+        return value.startIndex
+    }
+
+    /// End index.
+    public var endIndex: Value.Index {
+        return value.endIndex
+    }
+
+    /// Index after given index `i`.
+    public func index(after i: Value.Index) -> Value.Index {
+        return value.index(after: i)
+    }
+
+    public var indices: Value.Indices {
+        return value.indices
+    }
+
+    /// - returns: Element at the given `index`.
+    public subscript (index: Value.Index) -> Value.Element {
+        return value[index]
     }
 }

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -11,6 +11,12 @@ public protocol NewType {
     init(value: Value)
 }
 
+extension NewType {
+    public init(_ value: Value) {
+        self.init(value: value)
+    }
+}
+
 extension NewType where Value: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Value.IntegerLiteralType) {
         self.init(value: Value(integerLiteral: value))
@@ -61,3 +67,8 @@ extension NewType where Value: Numeric {
 
 extension NewType where Value: SignedNumeric { }
 
+extension NewType where Value: Sequence {
+    public func makeIterator() -> Value.Iterator {
+        return value.makeIterator()
+    }
+}

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -16,3 +16,39 @@ extension NewType where Value: ExpressibleByIntegerLiteral {
         self.init(value: Value(integerLiteral: value))
     }
 }
+
+extension NewType where Value: Numeric {
+
+    public var magnitude: Value.Magnitude {
+        return value.magnitude
+    }
+
+    public static func + (lhs: Self, rhs: Self) -> Self {
+        return Self(value: lhs.value + rhs.value)
+    }
+
+    public static func += (lhs: inout Self, rhs: Self) {
+        lhs = lhs + rhs
+    }
+
+    public static func - (lhs: Self, rhs: Self) -> Self {
+        return Self(value: lhs.value - rhs.value)
+    }
+
+    public static func -= (lhs: inout Self, rhs: Self) {
+        lhs = lhs - rhs
+    }
+
+    public static func * (lhs: Self, rhs: Self) -> Self {
+        return Self(value: lhs.value * rhs.value)
+    }
+
+    public static func *= (lhs: inout Self, rhs: Self) {
+        lhs = lhs * rhs
+    }
+
+    public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let value = Value(exactly: source) else { return nil }
+        self.init(value: value)
+    }
+}

--- a/Sources/DataStructures/Stack.swift
+++ b/Sources/DataStructures/Stack.swift
@@ -22,11 +22,7 @@ public struct Stack <Element> {
 
     /// - returns: The `top` and the remaining items, if possible. Otherwise, `nil`.
     public var destructured: (Element, Stack<Element>)? {
-
-        guard self.count > 0 else {
-            return nil
-        }
-
+        guard self.count > 0 else { return nil }
         var copy = self
         let top = copy.pop()!
         return (top, copy)
@@ -101,6 +97,14 @@ extension Stack: Collection {
     public subscript (index: Int) -> Element {
         return elements[index]
     }
+
+    /// Count of elements contained herein.
+    ///
+    /// - Complexity: O(_1_)
+    ///
+    public var count: Int {
+        return elements.count
+    }
 }
 
 extension Stack: BidirectionalCollection {
@@ -109,14 +113,6 @@ extension Stack: BidirectionalCollection {
     public func index(before index: Int) -> Int {
         assert(index > 0, "Cannot decrement index to \(index - 1)")
         return index - 1
-    }
-
-    /// Count of elements contained herein.
-    ///
-    /// - Complexity: O(_1_)
-    ///
-    public var count: Int {
-        return elements.count
     }
 }
 

--- a/Sources/DataStructures/Wrapping/NewType.swift
+++ b/Sources/DataStructures/Wrapping/NewType.swift
@@ -1,0 +1,12 @@
+//
+//  NewType.swift
+//  DataStructures
+//
+//  Created by James Bean on 8/20/18.
+//
+
+public protocol NewType {
+    associatedtype Value
+    var value: Value { get }
+    init(value: Value)
+}

--- a/Tests/DataStructuresTests/NewTypeTests.swift
+++ b/Tests/DataStructuresTests/NewTypeTests.swift
@@ -40,4 +40,10 @@ class NewTypeTests: XCTestCase {
         let s = S([1,2,3])
         let _ = s.map { $0 }
     }
+
+    func testCollection() {
+        struct C: NewType, Collection { let value: [Int] }
+        let c = C([1,2,3])
+        let _ = c.count
+    }
 }

--- a/Tests/DataStructuresTests/NewTypeTests.swift
+++ b/Tests/DataStructuresTests/NewTypeTests.swift
@@ -34,4 +34,10 @@ class NewTypeTests: XCTestCase {
         let n: SN = 1
         let _ = -n
     }
+
+    func testSequence() {
+        struct S: NewType, Sequence { let value: [Int] }
+        let s = S([1,2,3])
+        let _ = s.map { $0 }
+    }
 }

--- a/Tests/DataStructuresTests/NewTypeTests.swift
+++ b/Tests/DataStructuresTests/NewTypeTests.swift
@@ -1,0 +1,37 @@
+//
+//  NewTypeTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 8/20/18.
+//
+
+import XCTest
+import DataStructures
+
+class NewTypeTests: XCTestCase {
+
+    func testExpressibleByIntegerLiteral() {
+        struct I: NewType, ExpressibleByIntegerLiteral { let value: Int }
+        let _: I = 42
+    }
+
+    func testExpressibleByFloatLiteral() {
+        struct F: NewType, ExpressibleByFloatLiteral { let value: Double }
+        let _: F = 42.0
+    }
+
+    func testNumeric() {
+        struct N: NewType, Numeric { let value: Double }
+        let a: N = 42
+        let b: N = 9000
+        let _ = a + b
+        let _ = a - b
+        let _ = a * b
+    }
+
+    func testSignedNumeric() {
+        struct SN: NewType, SignedNumeric { let value: Int }
+        let n: SN = 1
+        let _ = -n
+    }
+}


### PR DESCRIPTION
This PR implements the `NewType` protocol. 

The initial implementation of the protocol should eliminate the need for the `Int`, `Double`, and `Float` `Wrapping` protocols.

Ultimately, this should remove the need for the `Sequence`, and `Collection` `Wrapping` protocols, as well.

The `NewType` functions similarly to the Haskell `newtype`, in that the new type exposes the same interface as the original type.