### PR TITLE
Add Bimap

### DIFF
--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -131,7 +131,7 @@ extension Bimap {
     ///
     /// - Returns: The previous value for the given `key`, if it existed. Otherwise, `nil`.
     @discardableResult
-    public mutating func removeValueForKey(_ key: Key) -> Value? {
+    public mutating func removeValue(forKey key: Key) -> Value? {
         let previous = self[key: key]
         self[key: key] = nil
         return previous
@@ -141,7 +141,7 @@ extension Bimap {
     ///
     /// - Returns: The previous key for the given `value`, if it existed. Otherwise, `nil`.
     @discardableResult
-    public mutating func removeKeyForValue(_ value: Value) -> Key? {
+    public mutating func removeKey(forValue value: Value) -> Key? {
         let previous = self[value: value]
         self[value: value] = nil
         return previous

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -5,8 +5,8 @@
 //  Created by James Bean on 8/31/18.
 //
 
-/// Dictionary-like structure which allows O(1) access from `Key` to `Value` and from `Value` to
-/// `Key`.
+/// Dictionary-like structure which allows O(1) access from `Key` to `Value` as well as from `Value`
+/// to `Key`.
 public struct Bimap <Key: Hashable, Value: Hashable>: Hashable {
 
     // MARK: - Instance Properties

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -166,6 +166,32 @@ extension Bimap {
     }
 }
 
+extension Bimap: DictionaryProtocol {
+
+    /// Gets and sets the value for the `key`.
+    public subscript(key: Key) -> Value? {
+        get { return self[key: key] }
+        set { self[key: key] = newValue }
+    }
+
+    /// Reserves the amount of memory needed to store the given `minimumCapacity` of key-value
+    /// pairs.
+    public mutating func reserveCapacity(_ minimumCapacity: Int) {
+        valueByKey.reserveCapacity(minimumCapacity)
+        keyByValue.reserveCapacity(minimumCapacity)
+    }
+}
+
+extension Bimap: CollectionWrapping {
+
+    // MARK: - CollectionWrapping
+
+    /// - Returns: The `[Key: Value]` base for `Collection` operations.
+    public var base: [Key: Value] {
+        return valueByKey
+    }
+}
+
 extension Bimap: ExpressibleByDictionaryLiteral {
 
     // MARK: ExpressibleByDictionaryLiteral Protocol Conformance

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -82,35 +82,23 @@ extension Bimap {
 
     /// Get and set the `Key` for the given `value`.
     public subscript(value value: Value) -> Key? {
-        get {
-            return keyByValue[value]
-        }
+        get { return keyByValue[value] }
         set(newKey) {
             let oldKey = keyByValue.removeValue(forKey: value)
-            if let oldKey = oldKey {
-                valueByKey.removeValue(forKey: oldKey)
-            }
+            if let oldKey = oldKey { valueByKey.removeValue(forKey: oldKey) }
             keyByValue[value] = newKey
-            if let newKey = newKey {
-                valueByKey[newKey] = value
-            }
+            if let newKey = newKey { valueByKey[newKey] = value }
         }
     }
 
     /// Get and set the `Value` for the given `key`.
     public subscript(key key: Key) -> Value? {
-        get {
-            return valueByKey[key]
-        }
+        get { return valueByKey[key] }
         set {
             let oldValue = valueByKey.removeValue(forKey: key)
-            if let oldValue = oldValue {
-                keyByValue.removeValue(forKey: oldValue)
-            }
+            if let oldValue = oldValue { keyByValue.removeValue(forKey: oldValue) }
             valueByKey[key] = newValue
-            if let newValue = newValue {
-                keyByValue[newValue] = key
-            }
+            if let newValue = newValue { keyByValue[newValue] = key }
         }
     }
 }

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -1,0 +1,176 @@
+//
+//  Bimap.swift
+//  DataStructures
+//
+//  Created by James Bean on 8/31/18.
+//
+
+/// Dictionary-like structure which allows O(1) access from `Key` to `Value` and from `Value` to
+/// `Key`.
+public struct Bimap <Key: Hashable, Value: Hashable>: Hashable {
+
+    // MARK: - Instance Properties
+
+    private var valueByKey: [Key: Value]
+    private var keyByValue: [Value: Key]
+}
+
+extension Bimap {
+
+    // MARK: - Initializers
+
+    /// Create an empty `Bimap`.
+    public init() {
+        self.valueByKey = [:]
+        self.keyByValue = [:]
+    }
+
+    /// Create an empty `Bimap` reserving the amount of memory needed to store the given
+    /// `minimumCapacity` of key-value pairs.
+    public init(minimumCapacity: Int) {
+        valueByKey = [Key: Value](minimumCapacity: minimumCapacity)
+        keyByValue = [Value: Key](minimumCapacity: minimumCapacity)
+    }
+
+    /// Create a `Bimap` from a dictionary.
+    public init(_ elements: Dictionary<Key, Value>) {
+        self.init(minimumCapacity: elements.count)
+        for (k, value) in elements { self[key: k] = value }
+    }
+
+    /// Create a `Bimap` from the given `sequence` of key-value pairs.
+    public init <S: Sequence> (_ sequence: S) where S.Element == (Key, Value) {
+        self.init()
+        for (k, value) in sequence { self[key: k] = value }
+    }
+
+    /// Create a `Bimap` from the given `collection` of key-value pairs.
+    public init <C: Collection> (_ collection: C) where C.Element == (Key, Value) {
+        self.init(minimumCapacity: collection.count)
+        for (k, value) in collection { self[key: k] = value }
+    }
+}
+
+extension Bimap {
+
+    // MARK: - Computed Properties
+
+    /// - Returns: The amount of key-value pairs contained herein.
+    public var count: Int {
+        return valueByKey.count
+    }
+
+    /// - Returns: `true` if there are no key-value pairs contained herein. Otherwise, `false`.
+    public var isEmpty: Bool {
+        return valueByKey.isEmpty
+    }
+
+    /// - Returns: A collection of `Key` values.
+    public var keys: AnyCollection<Key> {
+        return AnyCollection(valueByKey.keys)
+    }
+
+    /// - Returns: A collection of `Value` values.
+    public var values: AnyCollection<Value> {
+        return AnyCollection(keyByValue.keys)
+    }
+}
+
+extension Bimap {
+
+    // MARK: - Subscripts
+
+    /// Get and set the `Key` for the given `value`.
+    public subscript(value value: Value) -> Key? {
+        get {
+            return keyByValue[value]
+        }
+        set(newKey) {
+            let oldKey = keyByValue.removeValue(forKey: value)
+            if let oldKey = oldKey {
+                valueByKey.removeValue(forKey: oldKey)
+            }
+            keyByValue[value] = newKey
+            if let newKey = newKey {
+                valueByKey[newKey] = value
+            }
+        }
+    }
+
+    /// Get and set the `Value` for the given `key`.
+    public subscript(key key: Key) -> Value? {
+        get {
+            return valueByKey[key]
+        }
+        set {
+            let oldValue = valueByKey.removeValue(forKey: key)
+            if let oldValue = oldValue {
+                keyByValue.removeValue(forKey: oldValue)
+            }
+            valueByKey[key] = newValue
+            if let newValue = newValue {
+                keyByValue[newValue] = key
+            }
+        }
+    }
+}
+
+extension Bimap {
+
+    // MARK: - Instance Methods
+
+    /// Updates the current value to the given `value` for the given `key`.
+    ///
+    /// - Returns: The previous value for the given `key`, if it existed. Otherwise, `nil`.
+    @discardableResult
+    public mutating func updateValue(_ value: Value, forKey key: Key) -> Value? {
+        let previous = self[key: key]
+        self[key: key] = value
+        return previous
+    }
+
+    /// Updates the current key to the given `key` for the given `value`.
+    ///
+    /// - Returns: The previous key for the given `value`, if it existed. Otherwise, `nil`.
+    @discardableResult
+    public mutating func updateKey(_ key: Key, forValue value: Value) -> Key? {
+        let previous = self[value: value]
+        self[value: value] = key
+        return previous
+    }
+
+    /// Removes the value for the given `key`.
+    ///
+    /// - Returns: The previous value for the given `key`, if it existed. Otherwise, `nil`.
+    @discardableResult
+    public mutating func removeValueForKey(_ key: Key) -> Value? {
+        let previous = self[key: key]
+        self[key: key] = nil
+        return previous
+    }
+
+    /// Removes the key for the given `value`.
+    ///
+    /// - Returns: The previous key for the given `value`, if it existed. Otherwise, `nil`.
+    @discardableResult
+    public mutating func removeKeyForValue(_ value: Value) -> Key? {
+        let previous = self[value: value]
+        self[value: value] = nil
+        return previous
+    }
+
+    /// Removes all key-value pairs, without releasing memory.
+    public mutating func removeAll(keepCapacity capacity: Bool = true) {
+        keyByValue.removeAll(keepingCapacity: capacity)
+        valueByKey.removeAll(keepingCapacity: capacity)
+    }
+}
+
+extension Bimap: ExpressibleByDictionaryLiteral {
+
+    // MARK: ExpressibleByDictionaryLiteral Protocol Conformance
+    /// Constructs a bimap using a dictionary literal.
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self.init(elements)
+    }
+}

--- a/Tests/DataStructuresTests/BimapTests.swift
+++ b/Tests/DataStructuresTests/BimapTests.swift
@@ -1,0 +1,73 @@
+//
+//  BimapTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 8/31/18.
+//
+
+import XCTest
+import DataStructures
+
+class BimapTests: XCTestCase {
+
+    func testInitEmpty() {
+        let bimap: Bimap<Int,Int> = [:]
+        XCTAssertEqual(bimap.count, 0)
+        XCTAssert(bimap.isEmpty)
+    }
+
+    func testKeySubscript() {
+        var bimap: Bimap<Int,Int> = [:]
+        bimap[key: 0] = 10
+        XCTAssertEqual(bimap[key: 0], 10)
+    }
+
+    func testValueSubscript() {
+        var bimap: Bimap<Int,Int> = [:]
+        bimap[value: 10] = 0
+        XCTAssertEqual(bimap[value: 10], 0)
+    }
+
+    func testUpdateValue() {
+        var bimap: Bimap = [0: 10, 1: 11, 2: 12, 3: 13]
+        bimap.updateValue(111, forKey: 1)
+        XCTAssertEqual(bimap[key: 0], 10)
+        XCTAssertEqual(bimap[key: 1], 111)
+        XCTAssertEqual(bimap[key: 2], 12)
+        XCTAssertEqual(bimap[key: 3], 13)
+    }
+
+    func testUpdateKey() {
+        var bimap: Bimap = [10: 0, 11: 1, 12: 2, 13: 3]
+        bimap.updateKey(111, forValue: 1)
+        XCTAssertEqual(bimap[value: 0], 10)
+        XCTAssertEqual(bimap[value: 1], 111)
+        XCTAssertEqual(bimap[value: 2], 12)
+        XCTAssertEqual(bimap[value: 3], 13)
+    }
+
+    func testRemoveValue() {
+        var bimap: Bimap = [0: 10, 1: 11, 2: 12, 3: 13]
+        bimap.removeValue(forKey: 1)
+        XCTAssertEqual(bimap[key: 0], 10)
+        XCTAssertEqual(bimap[key: 1], nil)
+        XCTAssertEqual(bimap[key: 2], 12)
+        XCTAssertEqual(bimap[key: 3], 13)
+    }
+
+    func testRemoveKey() {
+        var bimap: Bimap = [10: 0, 11: 1, 12: 2, 13: 3]
+        bimap.removeKey(forValue: 1)
+        XCTAssertEqual(bimap[value: 0], 10)
+        XCTAssertEqual(bimap[value: 1], nil)
+        XCTAssertEqual(bimap[value: 2], 12)
+        XCTAssertEqual(bimap[value: 3], 13)
+    }
+
+    func testRemoveAll() {
+        var bimap: Bimap = [0: 0, 1: 1, 2: 2, 3: 3]
+        bimap.removeAll()
+        XCTAssertEqual(bimap.count, 0)
+        XCTAssert(bimap.isEmpty)
+    }
+}

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -21,6 +21,19 @@ extension ArrayExtensionsTests {
     ]
 }
 
+extension BimapTests {
+    static let __allTests = [
+        ("testInitEmpty", testInitEmpty),
+        ("testKeySubscript", testKeySubscript),
+        ("testRemoveAll", testRemoveAll),
+        ("testRemoveKey", testRemoveKey),
+        ("testRemoveValue", testRemoveValue),
+        ("testUpdateKey", testUpdateKey),
+        ("testUpdateValue", testUpdateValue),
+        ("testValueSubscript", testValueSubscript),
+    ]
+}
+
 extension BinaryHeapTests {
     static let __allTests = [
         ("testBalance", testBalance),
@@ -94,8 +107,8 @@ extension DictionaryProtocolsTests {
         ("testSafelyAppendContentsToNotYetExtant", testSafelyAppendContentsToNotYetExtant),
         ("testSafelyAppendToExisting", testSafelyAppendToExisting),
         ("testSafelyAppendToNotYetExisting", testSafelyAppendToNotYetExisting),
-        ("testSafelyInsertContentsToExisting", testSafelyFormUnionExisting),
-        ("testSafelyInsertContentsToNotYetExtant", testSafelyFormUnionNotYetExtant),
+        ("testSafelyFormUnionExisting", testSafelyFormUnionExisting),
+        ("testSafelyFormUnionNotYetExtant", testSafelyFormUnionNotYetExtant),
         ("testSafelyInsertToExisting", testSafelyInsertToExisting),
         ("testSafelyInsertToNotYetExisting", testSafelyInsertToNotYetExisting),
     ]
@@ -443,6 +456,7 @@ extension ZipToLongestTests {
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ArrayExtensionsTests.__allTests),
+        testCase(BimapTests.__allTests),
         testCase(BinaryHeapTests.__allTests),
         testCase(CircularArrayTests.__allTests),
         testCase(ContiguousSegmentCollectionTests.__allTests),


### PR DESCRIPTION
This PR adds a `Bimap` structure, which allows O(1) access from `Key` to `Value` as well as from `Value` to `Key`.