### PR TITLE
Add Metatype

### DIFF
--- a/Sources/DataStructures/Metatype.swift
+++ b/Sources/DataStructures/Metatype.swift
@@ -1,0 +1,48 @@
+//
+//  Metatype.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/10/18.
+//
+
+/// A wrapper around the metatype of any type.
+///
+/// This wrapper allows a metatype (`T.Type`, `String.self`, etc.) to conform to `Equatable` and
+/// `Hashable`. Therefore, a metatype can be used as a key in a dictionary.
+public struct Metatype {
+
+    /// The metatype wrapped-up herein.
+    @usableFromInline
+    let base: Any.Type
+
+    // MARK: - Initializers
+
+    /// Creates a `Metatype` with the given `base` metatype to wrap.
+    @inlinable
+    public init(_ base: Any.Type) {
+        self.base = base
+    }
+}
+
+extension Metatype: Equatable {
+
+    // MARK: - Equatable
+
+    /// - Returns: `true` if the given metatypes wrapped up by the given `Metatype` values are
+    /// equivalent. Otherwise, `false`.
+    @inlinable
+    public static func == (lhs: Metatype, rhs: Metatype) -> Bool {
+        return lhs.base == rhs.base
+    }
+}
+
+extension Metatype: Hashable {
+
+    // MARK: - Hashable
+
+    /// - Returns: A unique hash value for the metatype wrapped-up herein.
+    @inlinable
+    public var hashValue: Int {
+        return ObjectIdentifier(base).hashValue
+    }
+}

--- a/Tests/DataStructuresTests/MetatypeTests.swift
+++ b/Tests/DataStructuresTests/MetatypeTests.swift
@@ -1,0 +1,42 @@
+//
+//  MetatypeTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 9/10/18.
+//
+
+import XCTest
+import DataStructures
+
+class MetatypeTests: XCTestCase {
+
+    func testInit() {
+        let _ = Metatype(String.self)
+        let _ = Metatype(Int.self)
+        let _ = Metatype(type(of: 42.0))
+    }
+
+    func testEquatable() {
+        let a = Metatype(Int.self)
+        let b = Metatype(type(of: 1))
+        XCTAssertEqual(a,b)
+    }
+
+    func testEquatableFalse() {
+        let a = Metatype(String.self)
+        let b = Metatype(type(of: 1))
+        XCTAssertNotEqual(a,b)
+    }
+
+    func testHashableEqual() {
+        let a = Metatype(String.self)
+        let b = Metatype(type(of: "test"))
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func testHashableNotEqual() {
+        let a = Metatype(Int.self)
+        let b = Metatype(type(of: "test"))
+        XCTAssertNotEqual(a.hashValue, b.hashValue)
+    }
+}

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -202,6 +202,16 @@ extension MatrixTests {
     ]
 }
 
+extension MetatypeTests {
+    static let __allTests = [
+        ("testEquatable", testEquatable),
+        ("testEquatableFalse", testEquatableFalse),
+        ("testHashableEqual", testHashableEqual),
+        ("testHashableNotEqual", testHashableNotEqual),
+        ("testInit", testInit),
+    ]
+}
+
 extension MutableGraphTests {
     static let __allTests = [
         ("testBidirectionalRelationshipIsTwoDirectedRelationships", testBidirectionalRelationshipIsTwoDirectedRelationships),
@@ -490,6 +500,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(InvertibleEnumTests.__allTests),
         testCase(LinkedListTests.__allTests),
         testCase(MatrixTests.__allTests),
+        testCase(MetatypeTests.__allTests),
         testCase(MutableGraphTests.__allTests),
         testCase(NewTypeTests.__allTests),
         testCase(OrderedDictionaryTests.__allTests),


### PR DESCRIPTION
This PR adds the `Metatype` wrapper for metatypes. This allows metatypes (e.g., `Int.self`, `type(of: 1)`) to be compared and hashed. Thus, you can use `Metatype` as a key in a `Dictionary` or in a `Set`.