### PR TITLE
Pull down Pair from dn-m/NotationModel/SpelledPitch

### DIFF
--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -1,0 +1,33 @@
+//
+//  Cross.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// `Pair` of two values with potentially different types.
+public struct Cross <T,U>: Pair {
+
+    // MARK: - Instance Properties
+
+    /// The first value contained herein.
+    public let a: T
+
+    /// The second value contained herein.
+    public let b: U
+}
+
+extension Cross {
+
+    // MARK: - Initializers
+
+    /// Creates a `Cross` with the given values.
+    @inlinable
+    public init(_ a: T, _ b: U) {
+        self.a = a
+        self.b = b
+    }
+}
+
+extension Cross: Equatable where T: Equatable, U: Equatable { }
+extension Cross: Hashable where T: Hashable, U: Hashable { }

--- a/Sources/DataStructures/Pair/OrderedPair.swift
+++ b/Sources/DataStructures/Pair/OrderedPair.swift
@@ -1,0 +1,33 @@
+//
+//  OrderedPair.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// `Pair` of two values of the same type for which the order of the values is meaningful.
+public struct OrderedPair <T>: SwappablePair {
+
+    // MARK: - Instance Properties
+
+    /// The first value contained herein.
+    public let a: T
+
+    /// The second value contained herein.
+    public let b: T
+}
+
+extension OrderedPair {
+
+    // MARK: - Initializers
+
+    /// Creates an `OrderedPair` with the given values.
+    @inlinable
+    public init(_ a: T, _ b: T) {
+        self.a = a
+        self.b = b
+    }
+}
+
+extension OrderedPair: Equatable where T: Equatable { }
+extension OrderedPair: Hashable where T: Hashable { }

--- a/Sources/DataStructures/Pair/Pair.swift
+++ b/Sources/DataStructures/Pair/Pair.swift
@@ -1,0 +1,34 @@
+//
+//  Pair.swift
+//  Algebra
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// Pair of two values.
+///
+/// `Pair` makes no assumptions about the equivalence of types, or order of the values contained
+/// herein.
+public protocol Pair {
+
+    // MARK: - Associated Types
+
+    /// The type of the first value contained herein.
+    associatedtype A
+
+    /// The type of the second value contained herein.
+    associatedtype B
+
+    // MARK: - Instance Properties
+
+    /// The first value contained herein.
+    var a: A { get }
+
+    /// The second value contained herein.
+    var b: B { get }
+
+    // MARK: - Initializers
+
+    /// Creates a `Pair` with the given values.
+    init(_ a: A, _ b: B)
+}

--- a/Sources/DataStructures/Pair/SwappablePair.swift
+++ b/Sources/DataStructures/Pair/SwappablePair.swift
@@ -1,0 +1,15 @@
+//
+//  SwappablePair.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// A `SymmetricPair` whose values can be interchanged.
+public protocol SwappablePair: SymmetricPair { }
+
+extension SwappablePair {
+    
+    /// - Returns: A `SwappablePair` wherein the values are swapped for one another.
+    public var swapped: Self { return .init(b,a) }
+}

--- a/Sources/DataStructures/Pair/SwappablePair.swift
+++ b/Sources/DataStructures/Pair/SwappablePair.swift
@@ -9,7 +9,7 @@
 public protocol SwappablePair: SymmetricPair { }
 
 extension SwappablePair {
-    
+
     /// - Returns: A `SwappablePair` wherein the values are swapped for one another.
     public var swapped: Self { return .init(b,a) }
 }

--- a/Sources/DataStructures/Pair/SymmetricPair.swift
+++ b/Sources/DataStructures/Pair/SymmetricPair.swift
@@ -1,0 +1,19 @@
+//
+//  SymmetricPair.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// A `Pair` in which the two values are of the same type.
+public protocol SymmetricPair: Pair where A == B { }
+
+extension SymmetricPair where A: Equatable {
+
+    /// - Returns: `true` if one of the values contained herein is equivalent to the given `value`.
+    /// Otherwise, `false`.
+    @inlinable
+    public func contains(_ value: A) -> Bool {
+        return a == value || b == value
+    }
+}

--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -1,0 +1,61 @@
+//
+//  UnorderedPair.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// `Pair` of two values of the same type for which the order of the values is not meaningful.
+public struct UnorderedPair <T>: SymmetricPair {
+
+    // MARK: - Instance Properties
+
+    /// The first value contained herein.
+    public let a: T
+
+    /// The second value contained herein.
+    public let b: T
+}
+
+extension UnorderedPair {
+
+    // MARK: - Initializers
+
+    /// Creates an `UnrderedPair` with the given values.
+    @inlinable
+    public init(_ a: T, _ b: T) {
+        self.a = a
+        self.b = b
+    }
+
+}
+
+extension UnorderedPair where T: Equatable {
+
+    /// - Returns: The value in this `UnorderedPair` other than the given `value`, if the given
+    /// `value` is contained herein. Otherwise, `nil`.
+    public func other(_ value: T) -> T? {
+        return a == value ? b : b == value ? a : nil
+    }
+}
+
+extension UnorderedPair: Equatable where T: Equatable {
+
+    // MARK: - Equatable
+
+    /// - Returns: `true` if both values contained by the given `UnorderedPair` values are
+    /// equivalent, regardless of order. Otherwise, `false`.
+    public static func == (_ lhs: UnorderedPair, _ rhs: UnorderedPair) -> Bool {
+        return (lhs.a == rhs.a && lhs.b == rhs.b) || (lhs.a == rhs.b && lhs.b == rhs.a)
+    }
+}
+
+extension UnorderedPair: Hashable where T: Hashable {
+
+    // MARK: - Hashable
+
+    /// Implements hashable requirement.
+    public var hashValue: Int {
+        return Set([a,b]).hashValue
+    }
+}


### PR DESCRIPTION
This PR adds a constellation of protocols and concrete types for creating various pairs of values.

The protocols are:

- `Pair`
- `SymmetricPair`
- `SwappablePair`

The concrete types are:

- `Cross`
- `UnorderedPair`
- `OrderedPair`

