### PR TITLE
Pull down Queue from dn-m/NotationModel/SpelledPitch

### DIFF
--- a/Sources/DataStructures/Queue.swift
+++ b/Sources/DataStructures/Queue.swift
@@ -1,0 +1,69 @@
+//
+//  Queue.swift
+//  DataStructures
+//
+//  Created by James Bean on 9/27/18.
+//
+
+/// First-in-first-out linear data structure.
+public struct Queue <Element> {
+
+    // MARK: - Instance Properties
+
+    @usableFromInline
+    var storage: [Element]
+}
+
+extension Queue {
+
+    // MARK: - Initializers
+
+    /// Creates an empty `Queue`.
+    public init() {
+        self.storage = []
+    }
+}
+
+extension Queue {
+
+    // MARK: - Computed Properties
+
+    /// - Returns: `true` if there are no values contained herein. Otherwise, `false`.
+    @inlinable
+    public var isEmpty: Bool {
+        return peek == nil
+    }
+
+    /// - Returns: The next value to be dequeued, if it exists. Otherwise, `nil`.
+    @inlinable
+    public var peek: Element? {
+        return storage.first
+    }
+}
+
+extension Queue {
+
+    // MARK: - Instance Methods
+
+    /// Adds the value to the `Queue`.
+    ///
+    /// - Complexity: O(*1*) amortized
+    @inlinable
+    public mutating func enqueue(_ value: Element) {
+        storage.append(value)
+    }
+
+    /// Removes the next value in the `Queue` and returns it.
+    ///
+    /// - Returns: The next value in the `Queue`.
+    ///
+    /// - Warning: If `.isEmpty`, `dequeue()` will crash. If necessary, check that `peek` returns
+    /// a non-`nil` value before dequeueing.
+    ///
+    /// - Complexity: O(*n*)
+    @inlinable
+    public mutating func dequeue() -> Element {
+        return storage.remove(at: 0)
+    }
+}
+

--- a/Sources/DataStructures/Queue.swift
+++ b/Sources/DataStructures/Queue.swift
@@ -5,7 +5,10 @@
 //  Created by James Bean on 9/27/18.
 //
 
-/// First-in-first-out linear data structure.
+/// First-in-last-out linear data structure.
+///
+/// - Remark: Consider using two linked lists instead of an `Array` as the internal storage.
+/// `Array` gives `O(*n*)` performance for `remove(at:)`, which is used by `dequeue`.
 public struct Queue <Element> {
 
     // MARK: - Instance Properties
@@ -66,4 +69,3 @@ extension Queue {
         return storage.remove(at: 0)
     }
 }
-

--- a/Sources/DataStructures/Queue.swift
+++ b/Sources/DataStructures/Queue.swift
@@ -66,6 +66,6 @@ extension Queue {
     /// - Complexity: O(*n*)
     @inlinable
     public mutating func dequeue() -> Element {
-        return storage.remove(at: 0)
+        return storage.removeFirst()
     }
 }

--- a/Tests/DataStructuresPerformanceTests/BinaryHeapPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/BinaryHeapPerformanceTests.swift
@@ -11,7 +11,7 @@ import DataStructures
 
 class BinaryHeapPerformanceTests: XCTestCase {
 
-    /// Guarantee that insertion into `BinaryHeap` is O(1).
+    /// Guarantee that insertion into `BinaryHeap` is O(*1*).
     func testInsert_O_1() {
         let benchmark = Benchmark.mutating(
             testPoints: Scale.small,
@@ -24,7 +24,7 @@ class BinaryHeapPerformanceTests: XCTestCase {
         XCTAssert(benchmark.performance(is: .constant))
     }
 
-    /// Guarantee that popping the minimum value from `BinaryHeap` is O(1).
+    /// Guarantee that popping the minimum value from `BinaryHeap` is O(*1*).
     func testPop_O_1() {
         let benchmark = Benchmark.mutating(
             testPoints: Scale.small,

--- a/Tests/DataStructuresPerformanceTests/QueuePerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/QueuePerformanceTests.swift
@@ -19,6 +19,8 @@ class QueuePerformanceTests: XCTestCase {
         XCTAssert(benchmark.performance(is: .constant))
     }
 
+    // If this is tested against `.constant`, this test also passes. The tolerance for `.constant`
+    // performance should probably be tightened.
     func testDequeue_O_n() {
         let benchmark = Benchmark.mutating(
             setup: { size -> Queue<Int> in
@@ -28,7 +30,30 @@ class QueuePerformanceTests: XCTestCase {
             },
             measuring: { _ = $0.dequeue() }
         )
-        print(benchmark)
         XCTAssert(benchmark.performance(is: .linear))
+    }
+
+    func testPeek_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: { size -> Queue<Int> in
+                var q = Queue<Int>()
+                (0..<size).forEach { q.enqueue($0) }
+                return q
+            },
+            measuring: { _ = $0.peek }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
+    }
+
+    func testIsEmpty_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: { size -> Queue<Int> in
+                var q = Queue<Int>()
+                (0..<size).forEach { q.enqueue($0) }
+                return q
+        },
+            measuring: { _ = $0.isEmpty }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
     }
 }

--- a/Tests/DataStructuresPerformanceTests/QueuePerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/QueuePerformanceTests.swift
@@ -1,0 +1,34 @@
+//
+//  QueuePerformanceTests.swift
+//  DataStructuresPerformanceTests
+//
+//  Created by James Bean on 9/27/18.
+//
+
+import XCTest
+import PerformanceTesting
+import DataStructures
+
+class QueuePerformanceTests: XCTestCase {
+
+    func testEnqueue_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: { _ in Queue<Int>() },
+            measuring: { $0.enqueue(0) }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
+    }
+
+    func testDequeue_O_n() {
+        let benchmark = Benchmark.mutating(
+            setup: { size -> Queue<Int> in
+                var q = Queue<Int>()
+                (0..<size).forEach { q.enqueue($0) }
+                return q
+            },
+            measuring: { _ = $0.dequeue() }
+        )
+        print(benchmark)
+        XCTAssert(benchmark.performance(is: .linear))
+    }
+}

--- a/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
+++ b/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
@@ -7,10 +7,20 @@ extension BinaryHeapPerformanceTests {
     ]
 }
 
+extension QueuePerformanceTests {
+    static let __allTests = [
+        ("testDequeue_O_n", testDequeue_O_n),
+        ("testEnqueue_O_1", testEnqueue_O_1),
+        ("testIsEmpty_O_1", testIsEmpty_O_1),
+        ("testPeek_O_1", testPeek_O_1),
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(BinaryHeapPerformanceTests.__allTests),
+        testCase(QueuePerformanceTests.__allTests),
     ]
 }
 #endif

--- a/Tests/DataStructuresTests/QueueTests.swift
+++ b/Tests/DataStructuresTests/QueueTests.swift
@@ -1,0 +1,40 @@
+//
+//  QueueTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 9/27/18.
+//
+
+import XCTest
+import DataStructures
+
+class QueueTests: XCTestCase {
+
+    func testInitEmpty() {
+        let q = Queue<Int>()
+        XCTAssert(q.isEmpty)
+    }
+
+    func testInitPeekNil() {
+        let q = Queue<Int>()
+        XCTAssertNil(q.peek)
+    }
+
+    func testEnqueuedNotEmpty() {
+        var q = Queue<Int>()
+        q.enqueue(0)
+        XCTAssertFalse(q.isEmpty)
+    }
+
+    func testEnqueuedPeekNotNil() {
+        var q = Queue<Int>()
+        q.enqueue(0)
+        XCTAssertEqual(q.peek, 0)
+    }
+
+    func testEnqueuedDequeue() {
+        var q = Queue<Int>()
+        q.enqueue(0)
+        XCTAssertEqual(q.dequeue(), 0)
+    }
+}

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -256,6 +256,16 @@ extension PairsTests {
     ]
 }
 
+extension QueueTests {
+    static let __allTests = [
+        ("testEnqueuedDequeue", testEnqueuedDequeue),
+        ("testEnqueuedNotEmpty", testEnqueuedNotEmpty),
+        ("testEnqueuedPeekNotNil", testEnqueuedPeekNotNil),
+        ("testInitEmpty", testInitEmpty),
+        ("testInitPeekNil", testInitPeekNil),
+    ]
+}
+
 extension ReferenceTreeProtocolTests {
     static let __allTests = [
         ("testAddChild", testAddChild),
@@ -505,6 +515,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(NewTypeTests.__allTests),
         testCase(OrderedDictionaryTests.__allTests),
         testCase(PairsTests.__allTests),
+        testCase(QueueTests.__allTests),
         testCase(ReferenceTreeProtocolTests.__allTests),
         testCase(ReferenceTreeTests.__allTests),
         testCase(SortedArrayTests.__allTests),


### PR DESCRIPTION
This PR adds the `Queue` data structure, along with logical and performance tests.
