### PR TITLE
Push `edges` functions down to GraphProtocol

### DIFF
--- a/Sources/DataStructures/Graph/DirectedGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedGraph.swift
@@ -56,16 +56,5 @@ extension DirectedGraph {
     }
 }
 
-extension DirectedGraph {
-
-    // MARK: - Instance Methods
-
-    /// - Returns: A set of edges which emanate from the given `source` node.
-    @inlinable
-    public func edges(from source: Node) -> Set<Edge> {
-        return edges.filter { $0.a == source }
-    }
-}
-
 extension DirectedGraph: Equatable { }
 extension DirectedGraph: Hashable { }

--- a/Sources/DataStructures/Graph/Protocols/DirectedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/DirectedGraphProtocol.swift
@@ -6,10 +6,4 @@
 //
 
 /// Interface for directed graphs.
-public protocol DirectedGraphProtocol: GraphProtocol where Edge == OrderedPair<Node> {
-
-    // MARK: - Instance Methods
-
-    /// - Returns: A set of edges which emanate from the given `source` node.
-    func edges(from source: Node) -> Set<Edge>
-}
+public protocol DirectedGraphProtocol: GraphProtocol where Edge == OrderedPair<Node> { }

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -63,6 +63,8 @@ extension GraphProtocol {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
     }
     
+    /// - Returns: A set of edges that contain the given `node` (either incident or
+    /// outgoing).
     public func edges(containing node: Node) -> Set<Edge> {
         return edges(from: node).union(edges(to: node))
     }

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -68,6 +68,11 @@ extension GraphProtocol {
     public func edges(from source: Node) -> Set<Edge> {
         return Set(neighbors(of: source).map { Edge(source, $0) })
     }
+    
+    @inlinable
+    public func edges(to destination: Node) -> Set<Edge> {
+        return Set(nodes.lazy.map { Edge($0, destination) }.filter(edges.contains))
+    }
 
     /// - Returns: An array of `Node` values in breadth first order.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -69,6 +69,7 @@ extension GraphProtocol {
         return Set(neighbors(of: source).map { Edge(source, $0) })
     }
     
+    /// - Returns: A set of edges incident to the given `destination`.
     @inlinable
     public func edges(to destination: Node) -> Set<Edge> {
         return Set(nodes.lazy.map { Edge($0, destination) }.filter(edges.contains))

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -65,6 +65,7 @@ extension GraphProtocol {
     
     /// - Returns: A set of edges that contain the given `node` (either incident or
     /// outgoing).
+    @inlinable
     public func edges(containing node: Node) -> Set<Edge> {
         return edges(from: node).union(edges(to: node))
     }

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -65,7 +65,7 @@ extension GraphProtocol {
     
     /// - Returns: A set of edges outgoing from the given `source`.
     @inlinable
-    public func edges(containing source: Node) -> Set<Edge> {
+    public func edges(from source: Node) -> Set<Edge> {
         return Set(neighbors(of: source).map { Edge(source, $0) })
     }
 

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -62,6 +62,11 @@ extension GraphProtocol {
     public func neighbors(of source: Node, in nodes: Set<Node>? = nil) -> Set<Node> {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
     }
+    
+    @inlinable
+    public func edges(containing source: Node) -> Set<Edge> {
+        return Set(neighbors(of: source).map { Edge(source, $0) })
+    }
 
     /// - Returns: An array of `Node` values in breadth first order.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -63,6 +63,7 @@ extension GraphProtocol {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
     }
     
+    /// - Returns: A set of edges outgoing from the given `source`.
     @inlinable
     public func edges(containing source: Node) -> Set<Edge> {
         return Set(neighbors(of: source).map { Edge(source, $0) })

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -49,6 +49,20 @@ extension GraphProtocol {
     public func contains(_ node: Node) -> Bool {
         return nodes.contains(node)
     }
+    
+    /// - Returns: `true` if this graph contains an edge between given `source` and `destination`.
+    /// Otherwise, `false`.
+    @inlinable
+    public func containsEdge(from source: Node, to destination: Node) -> Bool {
+        return contains(Edge(source,destination))
+    }
+    
+    /// Returns: `true` if the `GraphProtocol`-conforming type value contains the given `edge`.
+    /// Otherwise, `false`.
+    @inlinable
+    public func contains(_ edge: Edge) -> Bool {
+        return edges.contains(edge)
+    }
 
     /// - Returns: A set of nodes connected to the given `source`, in the given set of
     /// `nodes`.

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -33,9 +33,6 @@ public protocol GraphProtocol {
 
     /// Removes the edge from the given `source` to the given `destination`.
     mutating func removeEdge(from source: Node, to destination: Node)
-
-    /// - Returns: A set of edges containing the given `node`.
-    func edges(containing node: Node) -> Set<Edge>
 }
 
 extension GraphProtocol {
@@ -61,13 +58,6 @@ extension GraphProtocol {
     @inlinable
     public func neighbors(of source: Node, in nodes: Set<Node>? = nil) -> Set<Node> {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
-    }
-    
-    /// - Returns: A set of edges that contain the given `node` (either incident or
-    /// outgoing).
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges(from: node).union(edges(to: node))
     }
     
     /// - Returns: A set of edges outgoing from the given `source`.

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -63,6 +63,10 @@ extension GraphProtocol {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
     }
     
+    public func edges(containing node: Node) -> Set<Edge> {
+        return edges(from: node).union(edges(to: node))
+    }
+    
     /// - Returns: A set of edges outgoing from the given `source`.
     @inlinable
     public func edges(from source: Node) -> Set<Edge> {

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -43,7 +43,7 @@ extension UnweightedGraphProtocol {
     /// - Returns: A set of edges containing the given `node`.
     @inlinable
     public func edges(containing node: Node) -> Set<Edge> {
-        return edges.filter { $0.a == node || $0.b == node }
+        return edges(from: node)
     }
 }
 

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -39,12 +39,6 @@ extension UnweightedGraphProtocol {
     public func contains(_ edge: Edge) -> Bool {
         return edges.contains(edge)
     }
-
-    /// - Returns: A set of edges containing the given `node`.
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges(from: node)
-    }
 }
 
 extension UnweightedGraphProtocol {

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -32,17 +32,6 @@ extension UnweightedGraphProtocol {
 
 extension UnweightedGraphProtocol {
 
-    // MARK: - Querying
-
-    /// - Returns: `true` if this graph contains the given `edge`. Otherwise, `false`.
-    @inlinable
-    public func contains(_ edge: Edge) -> Bool {
-        return edges.contains(edge)
-    }
-}
-
-extension UnweightedGraphProtocol {
-
     // MARK: - Modifying
 
     /// Inserts an edge between the given `source` and `destination` nodes.

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -76,7 +76,7 @@ extension WeightedGraphProtocol {
     /// - Returns: A set of edges containing the given `node`.
     @inlinable
     public func edges(containing node: Node) -> Set<Edge> {
-        return Set(adjacents.keys.lazy.filter { $0.contains(node) })
+        return edges(from: node)
     }
 }
 

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -46,19 +46,6 @@ extension WeightedGraphProtocol {
         return Set(adjacents.keys.lazy)
     }
 
-    /// - Returns: `true` if this graph contains an edge between given `source` and `destination`.
-    /// Otherwise, `false`.
-    @inlinable
-    public func containsEdge(from source: Node, to destination: Node) -> Bool {
-        return contains(Edge(source,destination))
-    }
-
-    /// - Returns: `true` if this graph contains the given `edge`. Otherwise, `false`.
-    @inlinable
-    public func contains(_ edge: Edge) -> Bool {
-        return adjacents.keys.contains(edge)
-    }
-
     /// - Returns: The weight for the edge connecting the given `source` and `destination` nodes,
     /// if the given `edge` is contained herein. Otherwise, `nil`.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -72,12 +72,6 @@ extension WeightedGraphProtocol {
     public func weight(_ edge: Edge) -> Weight? {
         return adjacents[edge]
     }
-
-    /// - Returns: A set of edges containing the given `node`.
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges(from: node)
-    }
 }
 
 extension WeightedGraphProtocol {

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -44,17 +44,6 @@ extension WeightedDirectedGraph {
     }
 }
 
-extension WeightedDirectedGraph {
-
-    // MARK: - Instance Methods
-
-    /// - Returns: A set of edges which emanate from the given `source` node.
-    @inlinable
-    public func edges(from source: Node) -> Set<Edge> {
-        return Set(adjacents.keys.lazy.filter { $0.a == source })
-    }
-}
-
 extension WeightedDirectedGraph: Equatable { }
 extension WeightedDirectedGraph: Hashable where Weight: Hashable { }
 

--- a/Tests/DataStructuresTests/GraphTests/GraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/GraphTests.swift
@@ -39,15 +39,6 @@ class GraphTests: XCTestCase {
         XCTAssertEqual(graph.edges.count, 1)
     }
 
-    func testEdgesContainingNode() {
-        var graph = Graph<String>()
-        graph.insert("a")
-        graph.insert("b")
-        graph.insert("c")
-        graph.insertEdge(from: "a", to: "c")
-        XCTAssertEqual(graph.edges(containing: "a"), [UnorderedPair("a","c")])
-    }
-
     func testNeighbors() {
         var graph = Graph<String>()
         graph.insertEdge(from: "a", to: "b")

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -152,7 +152,6 @@ extension EitherTests {
 extension GraphTests {
     static let __allTests = [
         ("testBreadthFirstSearch", testBreadthFirstSearch),
-        ("testEdgesContainingNode", testEdgesContainingNode),
         ("testEdgesCount", testEdgesCount),
         ("testInsertNodes", testInsertNodes),
         ("testNeighbors", testNeighbors),


### PR DESCRIPTION
This PR pushes all functions called `edges` down to the lowest level graph protocol.

The result is `GraphProtocol` containing the following lines:

```swift
    /// - Returns: A set of edges that contain the given `node` (either incident or
    /// outgoing).
    @inlinable
    public func edges(containing node: Node) -> Set<Edge> {
        return edges(from: node).union(edges(to: node))
    }
    
    /// - Returns: A set of edges outgoing from the given `source`.
    @inlinable
    public func edges(from source: Node) -> Set<Edge> {
        return Set(neighbors(of: source).map { Edge(source, $0) })
    }
    
    /// - Returns: A set of edges incident to the given `destination`.
    @inlinable
    public func edges(to destination: Node) -> Set<Edge> {
        return Set(nodes.lazy.map { Edge($0, destination) }.filter(edges.contains))
    }
```

I'd like to propose removing `edges(containing:)` or limiting its scope to the undirected graphs (shifting it to `UndirectedGraphProtocol`) since `from` and `to` will cover all cases (they mean the same thing in the undirected case).