### PR TITLE
Move contains (edge) logic down to GraphProtocol

### DIFF
--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -53,6 +53,13 @@ extension GraphProtocol {
         return nodes.contains(node)
     }
     
+    /// - Returns: `true` if this graph contains an edge between given `source` and `destination`.
+    /// Otherwise, `false`.
+    @inlinable
+    public func containsEdge(from source: Node, to destination: Node) -> Bool {
+        return contains(Edge(source,destination))
+    }
+    
     /// Returns: `true` if the `GraphProtocol`-conforming type value contains the given `edge`.
     /// Otherwise, `false`.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -52,6 +52,11 @@ extension GraphProtocol {
     public func contains(_ node: Node) -> Bool {
         return nodes.contains(node)
     }
+    
+    @inlinable
+    public func contains(_ edge: Edge) -> Bool {
+        return edges.contains(edge)
+    }
 
     /// - Returns: A set of nodes connected to the given `source`, in the given set of
     /// `nodes`.

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -53,6 +53,8 @@ extension GraphProtocol {
         return nodes.contains(node)
     }
     
+    /// Returns: `true` if the `GraphProtocol`-conforming type value contains the given `edge`.
+    /// Otherwise, `false`.
     @inlinable
     public func contains(_ edge: Edge) -> Bool {
         return edges.contains(edge)

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -32,17 +32,6 @@ extension UnweightedGraphProtocol {
 
 extension UnweightedGraphProtocol {
 
-    // MARK: - Querying
-
-    /// - Returns: `true` if this graph contains the given `edge`. Otherwise, `false`.
-    @inlinable
-    public func contains(_ edge: Edge) -> Bool {
-        return edges.contains(edge)
-    }
-}
-
-extension UnweightedGraphProtocol {
-
     // MARK: - Modifying
 
     /// Inserts an edge between the given `source` and `destination` nodes.

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -53,12 +53,6 @@ extension WeightedGraphProtocol {
         return contains(Edge(source,destination))
     }
 
-    /// - Returns: `true` if this graph contains the given `edge`. Otherwise, `false`.
-    @inlinable
-    public func contains(_ edge: Edge) -> Bool {
-        return adjacents.keys.contains(edge)
-    }
-
     /// - Returns: The weight for the edge connecting the given `source` and `destination` nodes,
     /// if the given `edge` is contained herein. Otherwise, `nil`.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -46,13 +46,6 @@ extension WeightedGraphProtocol {
         return Set(adjacents.keys.lazy)
     }
 
-    /// - Returns: `true` if this graph contains an edge between given `source` and `destination`.
-    /// Otherwise, `false`.
-    @inlinable
-    public func containsEdge(from source: Node, to destination: Node) -> Bool {
-        return contains(Edge(source,destination))
-    }
-
     /// - Returns: The weight for the edge connecting the given `source` and `destination` nodes,
     /// if the given `edge` is contained herein. Otherwise, `nil`.
     @inlinable


### PR DESCRIPTION
In a similar vein to #174, moves `contains` edge queries to their most general position in the protocol hierarchy. `contains` is handled in the GraphProtocol with calls to `edges`, which is implemented downstream.