### PR TITLE
Minimize scope of edges(containing:) to UnweightedGraphProtocol

### DIFF
--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -33,9 +33,6 @@ public protocol GraphProtocol {
 
     /// Removes the edge from the given `source` to the given `destination`.
     mutating func removeEdge(from source: Node, to destination: Node)
-
-    /// - Returns: A set of edges containing the given `node`.
-    func edges(containing node: Node) -> Set<Edge>
 }
 
 extension GraphProtocol {
@@ -61,13 +58,6 @@ extension GraphProtocol {
     @inlinable
     public func neighbors(of source: Node, in nodes: Set<Node>? = nil) -> Set<Node> {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
-    }
-    
-    /// - Returns: A set of edges that contain the given `node` (either incident or
-    /// outgoing).
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges(from: node).union(edges(to: node))
     }
     
     /// - Returns: A set of edges outgoing from the given `source`.

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -39,6 +39,13 @@ extension UnweightedGraphProtocol {
     public func contains(_ edge: Edge) -> Bool {
         return edges.contains(edge)
     }
+
+    /// - Returns: A set of edges that contain the given `node` (either incident or
+    /// outgoing).
+    @inlinable
+    public func edges(containing node: Node) -> Set<Edge> {
+        return edges.filter { $0.contains(node) }
+    }
 }
 
 extension UnweightedGraphProtocol {


### PR DESCRIPTION
This PR removes the required method `edges(containing:)` from `GraphProtocol`, and adds it as a non-customizable default implementation of `UnweighedGraphProtocol`.