### PR TITLE
Remove GraphProtocol.edges(containing:)

### DIFF
--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -33,9 +33,6 @@ public protocol GraphProtocol {
 
     /// Removes the edge from the given `source` to the given `destination`.
     mutating func removeEdge(from source: Node, to destination: Node)
-
-    /// - Returns: A set of edges containing the given `node`.
-    func edges(containing node: Node) -> Set<Edge>
 }
 
 extension GraphProtocol {
@@ -61,13 +58,6 @@ extension GraphProtocol {
     @inlinable
     public func neighbors(of source: Node, in nodes: Set<Node>? = nil) -> Set<Node> {
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
-    }
-    
-    /// - Returns: A set of edges that contain the given `node` (either incident or
-    /// outgoing).
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges(from: node).union(edges(to: node))
     }
     
     /// - Returns: A set of edges outgoing from the given `source`.

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -39,6 +39,13 @@ extension UnweightedGraphProtocol {
     public func contains(_ edge: Edge) -> Bool {
         return edges.contains(edge)
     }
+
+    /// - Returns: A set of edges that contain the given `node` (either incident or
+    /// outgoing).
+    @inlinable
+    public func edges(containing node: Node) -> Set<Edge> {
+        return edges.filter { $0.contains(node) }
+    }
 }
 
 extension UnweightedGraphProtocol {

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -39,13 +39,6 @@ extension UnweightedGraphProtocol {
     public func contains(_ edge: Edge) -> Bool {
         return edges.contains(edge)
     }
-
-    /// - Returns: A set of edges that contain the given `node` (either incident or
-    /// outgoing).
-    @inlinable
-    public func edges(containing node: Node) -> Set<Edge> {
-        return edges.filter { $0.contains(node) }
-    }
 }
 
 extension UnweightedGraphProtocol {

--- a/Tests/DataStructuresTests/GraphTests/GraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/GraphTests.swift
@@ -39,15 +39,6 @@ class GraphTests: XCTestCase {
         XCTAssertEqual(graph.edges.count, 1)
     }
 
-    func testEdgesContainingNode() {
-        var graph = Graph<String>()
-        graph.insert("a")
-        graph.insert("b")
-        graph.insert("c")
-        graph.insertEdge(from: "a", to: "c")
-        XCTAssertEqual(graph.edges(containing: "a"), [UnorderedPair("a","c")])
-    }
-
     func testNeighbors() {
         var graph = Graph<String>()
         graph.insertEdge(from: "a", to: "b")

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -152,7 +152,6 @@ extension EitherTests {
 extension GraphTests {
     static let __allTests = [
         ("testBreadthFirstSearch", testBreadthFirstSearch),
-        ("testEdgesContainingNode", testEdgesContainingNode),
         ("testEdgesCount", testEdgesCount),
         ("testInsertNodes", testInsertNodes),
         ("testNeighbors", testNeighbors),


### PR DESCRIPTION
This PR removes the required method and implementations of `GraphProtocol.edges(containing:)`.

This method is not in use in any downstream operations. If it is absolutely necessary, it can be added later.