### PR TITLE
Loosen init requirements for Protocol implementation

### DIFF
--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -24,11 +24,6 @@ public protocol GraphProtocol {
     /// All of the edges contained herein.
     var edges: Set<Edge> { get }
 
-    // MARK: - Initializers
-
-    /// Creates a `GraphProtocol`-conforming type value with the given set of `nodes`.
-    init(_ nodes: Set<Node>)
-
     // MARK: - Instance Methods
 
     /// Removes the edge from the given `source` to the given `destination`.


### PR DESCRIPTION
The aim of this PR is to make the requirements of the graph protocols less stringent, enabling freer conformance (and supporting both `WeightedDirectedGraph` and `FlowNetwork` as conforming to the same protocols in a new roadmap).