### PR TITLE
Improve performance of UnorderedPair.hashValue

### DIFF
--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -52,6 +52,6 @@ extension UnorderedPair: Hashable where T: Hashable {
 
     /// Implements hashable requirement.
     public var hashValue: Int {
-        return Set([a,b]).hashValue
+        return a.hashValue ^ b.hashValue
     }
 }

--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -30,6 +30,7 @@ extension UnorderedPair where T: Equatable {
 
     /// - Returns: The value in this `UnorderedPair` other than the given `value`, if the given
     /// `value` is contained herein. Otherwise, `nil`.
+    @inlinable
     public func other(_ value: T) -> T? {
         return a == value ? b : b == value ? a : nil
     }
@@ -41,6 +42,7 @@ extension UnorderedPair: Equatable where T: Equatable {
 
     /// - Returns: `true` if both values contained by the given `UnorderedPair` values are
     /// equivalent, regardless of order. Otherwise, `false`.
+    @inlinable
     public static func == (_ lhs: UnorderedPair, _ rhs: UnorderedPair) -> Bool {
         return (lhs.a == rhs.a && lhs.b == rhs.b) || (lhs.a == rhs.b && lhs.b == rhs.a)
     }
@@ -51,6 +53,7 @@ extension UnorderedPair: Hashable where T: Hashable {
     // MARK: - Hashable
 
     /// Implements hashable requirement.
+    @inlinable
     public var hashValue: Int {
         return a.hashValue ^ b.hashValue
     }

--- a/Tests/DataStructuresTests/UnorderedPairTests.swift
+++ b/Tests/DataStructuresTests/UnorderedPairTests.swift
@@ -46,4 +46,22 @@ class UnorderedPairTests: XCTestCase {
             }
         }
     }
+
+    func testManyHashValuesStringForCollisions() {
+        for _ in 0 ..< 1_000_000 {
+            let a = UnorderedPair(randomString(), randomString())
+            let b = UnorderedPair(randomString(), randomString())
+            if a == b {
+                XCTAssertEqual(a.hashValue, b.hashValue)
+            } else {
+                XCTAssertNotEqual(a.hashValue, b.hashValue)
+            }
+        }
+    }
+}
+
+func randomString(maxLength: Int = 10) -> String {
+    let alphaNumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    let count = Int.random(in: 1 ..< maxLength)
+    return String((0..<count).map { _ in alphaNumeric.randomElement()! })
 }

--- a/Tests/DataStructuresTests/UnorderedPairTests.swift
+++ b/Tests/DataStructuresTests/UnorderedPairTests.swift
@@ -1,0 +1,24 @@
+//
+//  UnorderedPairTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 10/1/18.
+//
+
+import XCTest
+import DataStructures
+
+class UnorderedPairTests: XCTestCase {
+
+    func testEquatable() {
+        let p1 = UnorderedPair("a","b")
+        let p2 = UnorderedPair("b","a")
+        XCTAssertEqual(p1, p2)
+    }
+
+    func testHashValue() {
+        let p1 = UnorderedPair("a","b")
+        let p2 = UnorderedPair("b","a")
+        XCTAssertEqual(p1.hashValue, p2.hashValue)
+    }
+}

--- a/Tests/DataStructuresTests/UnorderedPairTests.swift
+++ b/Tests/DataStructuresTests/UnorderedPairTests.swift
@@ -16,9 +16,22 @@ class UnorderedPairTests: XCTestCase {
         XCTAssertEqual(p1, p2)
     }
 
-    func testHashValue() {
+    func testHashValuesString() {
         let p1 = UnorderedPair("a","b")
         let p2 = UnorderedPair("b","a")
         XCTAssertEqual(p1.hashValue, p2.hashValue)
+    }
+
+    func testHashValuesInt() {
+        let p1 = UnorderedPair(1,2)
+        let p2 = UnorderedPair(2,1)
+        XCTAssertEqual(p1.hashValue, p2.hashValue)
+    }
+
+    func testManyHashValuesString() {
+        let p = UnorderedPair("a","b")
+        for _ in 0 ..< 1_000_000 {
+            _ = p.hashValue
+        }
     }
 }

--- a/Tests/DataStructuresTests/UnorderedPairTests.swift
+++ b/Tests/DataStructuresTests/UnorderedPairTests.swift
@@ -34,4 +34,16 @@ class UnorderedPairTests: XCTestCase {
             _ = p.hashValue
         }
     }
+
+    func testManyHashValuesIntForCollisions() {
+        for _ in 0 ..< 1_000_000 {
+            let a = UnorderedPair(Int.random(in: .min ... .max), Int.random(in: .min ... .max))
+            let b = UnorderedPair(Int.random(in: .min ... .max), Int.random(in: .min ... .max))
+            if a == b {
+                XCTAssertEqual(a.hashValue, b.hashValue)
+            } else {
+                XCTAssertNotEqual(a.hashValue, b.hashValue)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR improves the implementation of `UnorderedPair.hashValue`. 

While the `Set([a,b]).hashValue` implementation is logically correct, it incurs the penalty of the underlying reference-counted storage of `Set` each time. This adds up considerably. 

This implementation uses the `^` (XOR) operation, which, similarly to the `Set` implementation, does not recognize order of elements (which in this case is desired). The performance improves 97%.

Some research needs to be done to verify that this will be logically valid down the line.