### PR TITLE
Use hash(into:) for UnorderedPair Hashable conformance

### DIFF
--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -54,7 +54,7 @@ extension UnorderedPair: Hashable where T: Hashable {
 
     /// Implements hashable requirement.
     @inlinable
-    public var hashValue: Int {
-        return a.hashValue ^ b.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(a.hashValue ^ b.hashValue)
     }
 }


### PR DESCRIPTION
Closes #186.