### PR TITLE
Add data carrying graph types

### DIFF
--- a/Sources/DataStructures/Graph/DataGraph.swift
+++ b/Sources/DataStructures/Graph/DataGraph.swift
@@ -6,7 +6,7 @@
 //
 
 /// Unweighted, undirected graph with data carrying nodes.
-public struct DataGraph <Node: Hashable, Data: Hashable>:
+public struct DataGraph <Node: Hashable, Data>:
     UndirectedGraphProtocol,
     UnweightedCarrierGraphProtocol
 {
@@ -52,5 +52,5 @@ extension DataGraph {
     }
 }
 
-extension DataGraph: Equatable { }
-extension DataGraph: Hashable { }
+extension DataGraph: Equatable where Data: Equatable { }
+extension DataGraph: Hashable where Data: Hashable { }

--- a/Sources/DataStructures/Graph/DataGraph.swift
+++ b/Sources/DataStructures/Graph/DataGraph.swift
@@ -1,0 +1,56 @@
+//
+//  DataGraph.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+/// Unweighted, undirected graph with data carrying nodes.
+public struct DataGraph <Node: Hashable, Data: Hashable>:
+    UndirectedGraphProtocol,
+    UnweightedCarrierGraphProtocol
+{
+    
+    // MARK: - Instance Properties
+    
+    /// All of the nodes contained herein and the data they carry.
+    ///
+    /// A `Node` is any `Hashable`-conforming value.
+    public var data: [Node: Data]
+    
+    /// All of the edges contained herein.
+    ///
+    /// An `Edge` is an `UnorderedPair` of `Node` values.
+    public var edges: Set<Edge>
+}
+
+extension DataGraph {
+    
+    // MARK: - Type Aliases
+    
+    /// The type of edges which connect nodes.
+    public typealias Edge = UnorderedPair<Node>
+}
+
+extension DataGraph {
+    
+    // MARK: - Initializers
+    
+    /// Creates a `Graph` with the given set of nodes, with no edges between the nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:]) {
+        self.data = data
+        self.edges = []
+    }
+    
+    /// Creates a `Graph` with the given set of nodes and the given set of edges connecting the
+    /// nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:], _ edges: Set<Edge> = []) {
+        self.init(data)
+        self.edges = edges
+    }
+}
+
+extension DataGraph: Equatable { }
+extension DataGraph: Hashable { }

--- a/Sources/DataStructures/Graph/DirectedDataGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedDataGraph.swift
@@ -1,0 +1,56 @@
+//
+//  DirectedDataGraph.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+/// Unweighted, directed graph with data carrying nodes.
+public struct DirectedDataGraph <Node: Hashable, Data: Hashable>:
+    DirectedGraphProtocol,
+    UnweightedCarrierGraphProtocol
+{
+    
+    // MARK: - Instance Properties
+    
+    /// All of the nodes contained herein.
+    ///
+    /// A `Node` is any `Hashable`-conforming value.
+    public var data: [Node: Data]
+    
+    /// All of the edges contained herein.
+    ///
+    /// An `Edge` is an `OrderedPair` of `Node` values.
+    public var edges: Set<Edge>
+}
+
+extension DirectedDataGraph {
+    
+    // MARK: - Type Aliases
+    
+    /// The type of edges which connect nodes.
+    public typealias Edge = OrderedPair<Node>
+}
+
+extension DirectedDataGraph {
+    
+    // MARK: - Initializers
+    
+    /// Creates a `DirectedGraph` with the given node `data`, with no edges between the nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:]) {
+        self.data = data
+        self.edges = []
+    }
+    
+    /// Creates a `DirectedGraph` with the given node `data` and the given set of edges connecting the
+    /// nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:], _ edges: Set<Edge> = []) {
+        self.init(data)
+        self.edges = edges
+    }
+}
+
+extension DirectedDataGraph: Equatable { }
+extension DirectedDataGraph: Hashable { }

--- a/Sources/DataStructures/Graph/DirectedDataGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedDataGraph.swift
@@ -6,7 +6,7 @@
 //
 
 /// Unweighted, directed graph with data carrying nodes.
-public struct DirectedDataGraph <Node: Hashable, Data: Hashable>:
+public struct DirectedDataGraph <Node: Hashable, Data>:
     DirectedGraphProtocol,
     UnweightedCarrierGraphProtocol
 {
@@ -52,5 +52,5 @@ extension DirectedDataGraph {
     }
 }
 
-extension DirectedDataGraph: Equatable { }
-extension DirectedDataGraph: Hashable { }
+extension DirectedDataGraph: Equatable where Data: Equatable { }
+extension DirectedDataGraph: Hashable where Data: Hashable { }

--- a/Sources/DataStructures/Graph/DirectedGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedGraph.swift
@@ -7,9 +7,8 @@
 
 /// Unweighted, directed graph.
 public struct DirectedGraph <Node: Hashable>:
-    UnweightedGraphProtocol,
     DirectedGraphProtocol,
-    NonCarrierGraphProtocol
+    UnweightedNonCarrierGraphProtocol
 {
 
     // MARK: - Instance Properties

--- a/Sources/DataStructures/Graph/DirectedGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedGraph.swift
@@ -6,7 +6,11 @@
 //
 
 /// Unweighted, directed graph.
-public struct DirectedGraph <Node: Hashable>: UnweightedGraphProtocol, DirectedGraphProtocol {
+public struct DirectedGraph <Node: Hashable>:
+    UnweightedGraphProtocol,
+    DirectedGraphProtocol,
+    NonCarrierGraphProtocol
+{
 
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/Graph.swift
+++ b/Sources/DataStructures/Graph/Graph.swift
@@ -6,7 +6,11 @@
 //
 
 /// Unweighted, undirected graph.
-public struct Graph <Node: Hashable>: UnweightedGraphProtocol, UndirectedGraphProtocol {
+public struct Graph <Node: Hashable>:
+    UnweightedGraphProtocol,
+    UndirectedGraphProtocol,
+    NonCarrierGraphProtocol
+{
 
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/Graph.swift
+++ b/Sources/DataStructures/Graph/Graph.swift
@@ -7,9 +7,8 @@
 
 /// Unweighted, undirected graph.
 public struct Graph <Node: Hashable>:
-    UnweightedGraphProtocol,
     UndirectedGraphProtocol,
-    NonCarrierGraphProtocol
+    UnweightedNonCarrierGraphProtocol
 {
 
     // MARK: - Instance Properties

--- a/Sources/DataStructures/Graph/Protocols/CarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/CarrierGraphProtocol.swift
@@ -15,6 +15,11 @@ public protocol CarrierGraphProtocol: GraphProtocol {
 
 extension CarrierGraphProtocol {
     
+    @inlinable
+    public var nodes: Set<Node> {
+        return Set(data.keys.lazy)
+    }
+    
     /// Inserts the given `node` with the given data `value`.
     @inlinable
     public mutating func insert(_ node: Node, value: Data) {

--- a/Sources/DataStructures/Graph/Protocols/CarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/CarrierGraphProtocol.swift
@@ -1,0 +1,23 @@
+//
+//  CarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol CarrierGraphProtocol: GraphProtocol {
+    
+    associatedtype Data
+    
+    var data: [Node: Data] { get set }
+    
+}
+
+extension CarrierGraphProtocol {
+    
+    /// Inserts the given `node` with the given data `value`.
+    @inlinable
+    public mutating func insert(_ node: Node, value: Data) {
+        data[node] = value
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -32,12 +32,6 @@ public protocol GraphProtocol {
 
 extension GraphProtocol {
 
-    /// Inserts the given `node` without making any connections to other nodes contained herein.
-    @inlinable
-    public mutating func insert(_ node: Node) {
-        nodes.insert(node)
-    }
-
     /// - Returns: `true` if the `GraphProtocol`-conforming type value contains the given `node`.
     /// Otherwise, `false`.
     @inlinable

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -19,7 +19,7 @@ public protocol GraphProtocol {
     // MARK: - Instance Properties
 
     /// All of the nodes contained herein.
-    var nodes: Set<Node> { get set }
+    var nodes: Set<Node> { get }
 
     /// All of the edges contained herein.
     var edges: Set<Edge> { get }

--- a/Sources/DataStructures/Graph/Protocols/NonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/NonCarrierGraphProtocol.swift
@@ -16,6 +16,6 @@ extension NonCarrierGraphProtocol {
     /// Inserts the given `node` without making any connections to other nodes contained herein.
     @inlinable
     public mutating func insert(_ node: Node) {
-    nodes.insert(node)
+        nodes.insert(node)
     }
 }

--- a/Sources/DataStructures/Graph/Protocols/NonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/NonCarrierGraphProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  NonCarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol NonCarrierGraphProtocol: GraphProtocol {
+    
+    var nodes: Set<Node> { get set }
+    
+}
+
+extension NonCarrierGraphProtocol {
+    
+    /// Inserts the given `node` without making any connections to other nodes contained herein.
+    @inlinable
+    public mutating func insert(_ node: Node) {
+    nodes.insert(node)
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/UnweightedCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedCarrierGraphProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  UnweightedCarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol UnweightedCarrierGraphProtocol:
+    UnweightedGraphProtocol,
+    CarrierGraphProtocol
+{
+    // MARK: - Initializers
+    
+    /// Creates an `UnweightedCarrierGraphProtocol`-conforming type value with the given
+    /// set of `nodes` and the given set of `edges`.
+    init(_ data: [Node: Data], _ edges: Set<Edge>)
+}

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -34,12 +34,3 @@ extension UnweightedGraphProtocol {
         edges.remove(Edge(source,destination))
     }
 }
-
-extension UnweightedGraphProtocol {
-
-    /// - Returns: A new graph with the union of the nodes and edges of the two given graphs.
-    @inlinable
-    public static func + (lhs: Self, rhs: Self) -> Self {
-        return .init(lhs.nodes.union(rhs.nodes), lhs.edges.union(rhs.edges))
-    }
-}

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -37,6 +37,7 @@ extension UnweightedGraphProtocol {
     /// Inserts an edge between the given `source` and `destination` nodes.
     ///
     /// If the `source` or `destination` nodes are not yet contained herein, they are inserted.
+    /// - TODO: Implement error-raising for `source` or `destination` absent.
     @inlinable
     public mutating func insertEdge(from source: Node, to destination: Node) {
         edges.insert(Edge(source,destination))

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -39,8 +39,6 @@ extension UnweightedGraphProtocol {
     /// If the `source` or `destination` nodes are not yet contained herein, they are inserted.
     @inlinable
     public mutating func insertEdge(from source: Node, to destination: Node) {
-        insert(source)
-        insert(destination)
         edges.insert(Edge(source,destination))
     }
 

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -17,16 +17,6 @@ public protocol UnweightedGraphProtocol: GraphProtocol {
 
 extension UnweightedGraphProtocol {
 
-    /// Creates an `UnweightedGraphProtocol`-conforming type value which is composed a path of
-    /// nodes.
-    @inlinable
-    public init <S> (path: S) where S: Sequence, S.Element == Node {
-        self.init(Set(path), Set(path.pairs.map(Edge.init)))
-    }
-}
-
-extension UnweightedGraphProtocol {
-
     // MARK: - Modifying
 
     /// Inserts an edge between the given `source` and `destination` nodes.

--- a/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedGraphProtocol.swift
@@ -13,11 +13,6 @@ public protocol UnweightedGraphProtocol: GraphProtocol {
     /// All of the edges contained herein.
     var edges: Set<Edge> { get set }
 
-    // MARK: - Initializers
-
-    /// Creates an `UnweightedGraphProtocol`-conforming type value with the given set of `nodes`
-    /// and the given set of `edges`.
-    init(_ nodes: Set<Node>, _ edges: Set<Edge>)
 }
 
 extension UnweightedGraphProtocol {

--- a/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
@@ -25,3 +25,12 @@ extension UnweightedNonCarrierGraphProtocol {
         self.init(Set(path), Set(path.pairs.map(Edge.init)))
     }
 }
+
+extension UnweightedNonCarrierGraphProtocol {
+    
+    /// - Returns: A new graph with the union of the nodes and edges of the two given graphs.
+    @inlinable
+    public static func + (lhs: Self, rhs: Self) -> Self {
+        return .init(lhs.nodes.union(rhs.nodes), lhs.edges.union(rhs.edges))
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
@@ -15,3 +15,13 @@ public protocol UnweightedNonCarrierGraphProtocol:
     /// set of `nodes` and the given set of `edges`.
     init(_ nodes: Set<Node>, _ edges: Set<Edge>)
 }
+
+extension UnweightedNonCarrierGraphProtocol {
+    
+    /// Creates an `UnweightedGraphProtocol`-conforming type value which is composed a path of
+    /// nodes.
+    @inlinable
+    public init <S> (path: S) where S: Sequence, S.Element == Node {
+        self.init(Set(path), Set(path.pairs.map(Edge.init)))
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/UnweightedNonCarrierGraphProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  UnweightedNonCarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol UnweightedNonCarrierGraphProtocol:
+    UnweightedGraphProtocol,
+    NonCarrierGraphProtocol
+{
+    // MARK: - Initializers
+    
+    /// Creates an `UnweightedNonCarrierGraphProtocol`-conforming type value with the given
+    /// set of `nodes` and the given set of `edges`.
+    init(_ nodes: Set<Node>, _ edges: Set<Edge>)
+}

--- a/Sources/DataStructures/Graph/Protocols/WeightedCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedCarrierGraphProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  WeightedCarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol WeightedCarrierGraphProtocol:
+    WeightedGraphProtocol,
+    CarrierGraphProtocol
+{ }
+
+extension WeightedCarrierGraphProtocol {
+    
+    // MARK: - Transforming into unweighted graphs
+    
+    /// - Returns: An unweighted version of this `WeightedNonCarrierGraphProtocol`-conforming
+    /// type value.
+    @inlinable
+    public func unweighted <U> () -> U where U: UnweightedCarrierGraphProtocol,
+        U.Edge == Edge,
+        U.Node == Node,
+        U.Data == Data
+    {
+        return .init(data, Set(weights.keys.lazy))
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -21,17 +21,6 @@ public protocol WeightedGraphProtocol: GraphProtocol {
 
 extension WeightedGraphProtocol {
 
-    // MARK: - Transforming into unweighted graphs
-
-    /// - Returns: An unweighted version of this `WeightedGraphProtocol`-conforming type value.
-    @inlinable
-    public func unweighted <U> () -> U where U: UnweightedGraphProtocol, U.Edge == Edge {
-        return .init(nodes, Set(weights.keys.lazy))
-    }
-}
-
-extension WeightedGraphProtocol {
-
     // MARK: - Querying
 
     /// - Returns: All of the edges contained herein.

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -62,10 +62,9 @@ extension WeightedGraphProtocol {
     /// Inserts an edge between the given `source` and `destination` nodes, with the given `weight`.
     ///
     /// If the `source` or `destination` nodes are not yet contained herein, they are inserted.
+    /// - TODO: Implement error-raising for `source` or `destination` absent.
     @inlinable
     public mutating func insertEdge(from source: Node, to destination: Node, weight: Weight) {
-        nodes.insert(source)
-        nodes.insert(destination)
         weights[Edge(source,destination)] = weight
     }
 

--- a/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
@@ -14,7 +14,8 @@ extension WeightedNonCarrierGraphProtocol {
     
     // MARK: - Transforming into unweighted graphs
     
-    /// - Returns: An unweighted version of this `WeightedGraphProtocol`-conforming type value.
+    /// - Returns: An unweighted version of this `WeightedNonCarrierGraphProtocol`-conforming
+    /// type value.
     @inlinable
     public func unweighted <U> () -> U where U: UnweightedGraphProtocol, U.Edge == Edge {
         return .init(nodes, Set(weights.keys.lazy))

--- a/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  WeightedNonCarrierGraphProtocol.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+public protocol WeightedNonCarrierGraphProtocol:
+    WeightedGraphProtocol,
+    NonCarrierGraphProtocol
+{ }
+
+extension WeightedGraphProtocol {
+    
+    // MARK: - Transforming into unweighted graphs
+    
+    /// - Returns: An unweighted version of this `WeightedGraphProtocol`-conforming type value.
+    @inlinable
+    public func unweighted <U> () -> U where U: UnweightedGraphProtocol, U.Edge == Edge {
+        return .init(nodes, Set(weights.keys.lazy))
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
@@ -10,7 +10,7 @@ public protocol WeightedNonCarrierGraphProtocol:
     NonCarrierGraphProtocol
 { }
 
-extension WeightedGraphProtocol {
+extension WeightedNonCarrierGraphProtocol {
     
     // MARK: - Transforming into unweighted graphs
     

--- a/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedNonCarrierGraphProtocol.swift
@@ -17,7 +17,7 @@ extension WeightedNonCarrierGraphProtocol {
     /// - Returns: An unweighted version of this `WeightedNonCarrierGraphProtocol`-conforming
     /// type value.
     @inlinable
-    public func unweighted <U> () -> U where U: UnweightedGraphProtocol, U.Edge == Edge {
+    public func unweighted <U> () -> U where U: UnweightedNonCarrierGraphProtocol, U.Edge == Edge {
         return .init(nodes, Set(weights.keys.lazy))
     }
 }

--- a/Sources/DataStructures/Graph/WeightedDataGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDataGraph.swift
@@ -1,0 +1,56 @@
+//
+//  WeightedDataGraph.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+/// Weighted, undirected graph with data carrying nodes.
+public struct WeightedDataGraph <Node: Hashable, Data: Hashable, Weight: Numeric>:
+    UndirectedGraphProtocol,
+    WeightedCarrierGraphProtocol
+{
+    // MARK: - Instance Properties
+    
+    /// All of the node data contained herein.
+    ///
+    /// A `Node` is any `Hashable`-conforming value.
+    public var data: [Node: Data]
+    
+    /// All of the edges contained herein stored with their weight.
+    ///
+    /// An `Edge` is an `UnorderedPair` of `Node` values, and a `Weight` is any `Numeric`-conforming
+    /// value.
+    public var weights: [Edge: Weight]
+}
+
+extension WeightedDataGraph {
+    
+    // MARK: - Type Aliases
+    
+    /// The type of edges which connect nodes.
+    public typealias Edge = UnorderedPair<Node>
+}
+
+extension WeightedDataGraph {
+    
+    // MARK: - Initializers
+    
+    /// Creates a `WeightedDataGraph` with the given `data`, with no edges between the nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:]) {
+        self.data = data
+        self.weights = [:]
+    }
+    
+    /// Creates a `WeightedDataGraph` with the given `data` and the given dictionary of `weights`
+    /// stored by the applicable edge.
+    @inlinable
+    public init(_ data: [Node: Data] = [:], _ weights: [Edge: Weight] = [:]) {
+        self.init(data)
+        self.weights = weights
+    }
+}
+
+extension WeightedDataGraph: Equatable { }
+extension WeightedDataGraph: Hashable where Weight: Hashable { }

--- a/Sources/DataStructures/Graph/WeightedDataGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDataGraph.swift
@@ -6,7 +6,7 @@
 //
 
 /// Weighted, undirected graph with data carrying nodes.
-public struct WeightedDataGraph <Node: Hashable, Data: Hashable, Weight: Numeric>:
+public struct WeightedDataGraph <Node: Hashable, Data, Weight: Numeric>:
     UndirectedGraphProtocol,
     WeightedCarrierGraphProtocol
 {
@@ -52,5 +52,5 @@ extension WeightedDataGraph {
     }
 }
 
-extension WeightedDataGraph: Equatable { }
-extension WeightedDataGraph: Hashable where Weight: Hashable { }
+extension WeightedDataGraph: Equatable where Data: Equatable { }
+extension WeightedDataGraph: Hashable where Weight: Hashable, Data: Hashable { }

--- a/Sources/DataStructures/Graph/WeightedDirectedDataGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedDataGraph.swift
@@ -6,7 +6,7 @@
 //
 
 /// Weighted, directed graph with data carrying nodes.
-public struct WeightedDirectedDataGraph <Node: Hashable, Data: Hashable, Weight: Numeric>:
+public struct WeightedDirectedDataGraph <Node: Hashable, Data, Weight: Numeric>:
     DirectedGraphProtocol,
     WeightedCarrierGraphProtocol
 {
@@ -44,7 +44,7 @@ extension WeightedDirectedDataGraph {
     }
 }
 
-extension WeightedDirectedDataGraph: Equatable { }
-extension WeightedDirectedDataGraph: Hashable where Weight: Hashable { }
+extension WeightedDirectedDataGraph: Equatable where Data: Equatable { }
+extension WeightedDirectedDataGraph: Hashable where Weight: Hashable, Data: Hashable { }
 
 

--- a/Sources/DataStructures/Graph/WeightedDirectedDataGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedDataGraph.swift
@@ -1,0 +1,50 @@
+//
+//  WeightedDirectedDataGraph.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+/// Weighted, directed graph with data carrying nodes.
+public struct WeightedDirectedDataGraph <Node: Hashable, Data: Hashable, Weight: Numeric>:
+    DirectedGraphProtocol,
+    WeightedCarrierGraphProtocol
+{
+    // MARK: - Instance Properties
+    
+    public var data: [Node: Data]
+    public var weights: [Edge: Weight]
+}
+
+extension WeightedDirectedDataGraph {
+    
+    // MARK: - Type Aliases
+    
+    /// The type of edges which connect nodes.
+    public typealias Edge = OrderedPair<Node>
+}
+
+extension WeightedDirectedDataGraph {
+    
+    // MARK: - Initializers
+    
+    /// Creates a `Graph` with the given node `data`, with no edges between the nodes.
+    @inlinable
+    public init(_ data: [Node: Data] = [:]) {
+        self.data = data
+        self.weights = [:]
+    }
+    
+    /// Creates a `Graph` with the given node `data` and the given dictionary of `weights`
+    /// stored by the applicable edge.
+    @inlinable
+    public init(_ data: [Node: Data] = [:], _ weights: [Edge: Weight] = [:]) {
+        self.init(data)
+        self.weights = weights
+    }
+}
+
+extension WeightedDirectedDataGraph: Equatable { }
+extension WeightedDirectedDataGraph: Hashable where Weight: Hashable { }
+
+

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -8,7 +8,8 @@
 /// Weighted, directed graph.
 public struct WeightedDirectedGraph <Node: Hashable, Weight: Numeric>:
     WeightedGraphProtocol,
-    DirectedGraphProtocol
+    DirectedGraphProtocol,
+    NonCarrierGraphProtocol
 {
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -7,9 +7,8 @@
 
 /// Weighted, directed graph.
 public struct WeightedDirectedGraph <Node: Hashable, Weight: Numeric>:
-    WeightedGraphProtocol,
     DirectedGraphProtocol,
-    NonCarrierGraphProtocol
+    WeightedNonCarrierGraphProtocol
 {
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -7,9 +7,8 @@
 
 /// Weighted, undirected graph.
 public struct WeightedGraph <Node: Hashable, Weight: Numeric>:
-    WeightedGraphProtocol,
     UndirectedGraphProtocol,
-    NonCarrierGraphProtocol
+    WeightedNonCarrierGraphProtocol
 {
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -8,7 +8,8 @@
 /// Weighted, undirected graph.
 public struct WeightedGraph <Node: Hashable, Weight: Numeric>:
     WeightedGraphProtocol,
-    UndirectedGraphProtocol
+    UndirectedGraphProtocol,
+    NonCarrierGraphProtocol
 {
     // MARK: - Instance Properties
 

--- a/Tests/DataStructuresTests/GraphTests/DataGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/DataGraphTests.swift
@@ -1,0 +1,70 @@
+//
+//  DataGraphTests.swift
+//  DataStructuresTests
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+import XCTest
+import DataStructures
+
+class DataGraphTests: XCTestCase {
+    
+    func testNodesCount() {
+        var graph = DataGraph<Int,Int>()
+        (0..<10).forEach { graph.insert($0, value: $0) }
+        [(0,2), (1,4), (1,5), (4,7), (4,9)].forEach { graph.insertEdge(from: $0.0, to: $0.1) }
+        XCTAssertEqual(graph.nodes.count, 10)
+    }
+    
+    func testEdgesCount() {
+        var graph = DataGraph<Int,Int>()
+        (0..<10).forEach { graph.insert($0, value: $0) }
+        [(0,2), (1,4), (1,5), (4,7), (4,9)].forEach { graph.insertEdge(from: $0.0, to: $0.1) }
+        XCTAssertEqual(graph.edges.count, 5)
+    }
+    
+    func testInsertNodes() {
+        var result = DataGraph<Int,Int>()
+        [0,1].forEach { result.insert($0, value: $0) }
+        result.insertEdge(from: 0, to: 1)
+        let expected = DataGraph([0:0,1:1], [.init(0,1)])
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testRemoveEdge() {
+        var graph = DataGraph<String,Int>()
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "b", to: "c")
+        graph.removeEdge(from: "a", to: "b")
+        XCTAssertEqual(graph.edges.count, 1)
+    }
+    
+    func testNeighbors() {
+        var graph = DataGraph<String,Int>()
+        ["a":0,"b":1,"c":2].forEach { graph.insert($0, value: $1) }
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "a", to: "c")
+        XCTAssertEqual(graph.neighbors(of: "a"), ["b","c"])
+    }
+    
+    func testNeighborsInSet() {
+        var graph = DataGraph<String,Int>()
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "a", to: "c")
+        graph.insertEdge(from: "a", to: "d")
+        graph.insertEdge(from: "a", to: "e")
+        XCTAssertEqual(graph.neighbors(of: "a", in: ["c","d","f"]), ["c","d"])
+    }
+    
+    func testBreadthFirstSearch() {
+        var graph = DataGraph<String,Int>()
+        ["a":0,"b":1,"c":2,"d":3,"e":4].forEach { graph.insert($0, value: $1) }
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "b", to: "c")
+        graph.insertEdge(from: "c", to: "d")
+        graph.insertEdge(from: "d", to: "e")
+        XCTAssertEqual(graph.breadthFirstSearch(from: "e"), ["e","d","c","b","a"])
+        XCTAssertEqual(graph.breadthFirstSearch(from: "a"), ["a","b","c","d","e"])
+    }
+}

--- a/Tests/DataStructuresTests/GraphTests/DirectedDataGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/DirectedDataGraphTests.swift
@@ -1,0 +1,64 @@
+//
+//  DirectedDataGraphTests.swift
+//  DataStructures
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+import XCTest
+import DataStructures
+
+class DirectedDataGraphTests: XCTestCase {
+    
+    func testDirectedDataGraphInsertNodes() {
+        var result = DirectedDataGraph<String,Int>()
+        ["Zero": 0, "One": 1].forEach { result.insert($0, value: $1) }
+        result.insertEdge(from: "Zero", to: "One")
+        let expected = DirectedDataGraph(["Zero": 0,"One": 1], [.init("Zero","One")])
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testEdgesFromNode() {
+        var graph = DirectedDataGraph<String,Int>()
+        ["a":0,"b":1,"c":2,"d":3,"e":4].forEach { graph.insert($0, value: $1) }
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "b", to: "c")
+        graph.insertEdge(from: "b", to: "d")
+        graph.insertEdge(from: "d", to: "e")
+        XCTAssertEqual(graph.edges(from: "b"), [OrderedPair("b","c"),OrderedPair("b","d")])
+    }
+    
+    func testShortestUnweightedPathSingleNode() {
+        var graph = DirectedDataGraph<String,Int>()
+        graph.insert("a", value: 1)
+        XCTAssertEqual(graph.shortestUnweightedPath(from: "a", to: "a"), ["a"])
+    }
+    
+    func testShortestUnweightedPathTwoUnconnectedNodes() {
+        var graph = DirectedDataGraph<String, Int>()
+        graph.insert("a", value: 0)
+        graph.insert("b", value: 1)
+        XCTAssertNil(graph.shortestUnweightedPath(from: "a", to: "b"))
+    }
+    
+    func testShortestUnweightedPathTwoDirectionallyConnectedNodes() {
+        var graph = DirectedDataGraph<String, Int>()
+        graph.insert("a", value: 0)
+        graph.insert("b", value: 1)
+        graph.insertEdge(from: "a", to: "b")
+        XCTAssertEqual(graph.shortestUnweightedPath(from: "a", to: "b"), ["a", "b"])
+        XCTAssertNil(graph.shortestUnweightedPath(from: "b", to: "a"))
+    }
+    
+    func testShortestPathThreeNodes() {
+        var graph = DirectedDataGraph<String, Int>()
+        graph.insert("a", value: 0)
+        graph.insert("b", value: 1)
+        graph.insert("c", value: 2)
+        graph.insertEdge(from: "a", to: "b")
+        graph.insertEdge(from: "b", to: "c")
+        graph.insertEdge(from: "c", to: "b")
+        XCTAssertEqual(graph.shortestUnweightedPath(from: "a", to: "c"), ["a", "b", "c"])
+        XCTAssertEqual(graph.shortestUnweightedPath(from: "a", to: "b"), ["a", "b"])
+    }
+}

--- a/Tests/DataStructuresTests/GraphTests/DirectedGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/DirectedGraphTests.swift
@@ -12,6 +12,7 @@ class DirectedGraphTests: XCTestCase {
 
     func testDirectedGraphInsertNodes() {
         var result = DirectedGraph<String>()
+        ["Zero","One"].forEach { result.insert($0) }
         result.insertEdge(from: "Zero", to: "One")
         let expected = DirectedGraph(["Zero","One"], [.init("Zero","One")])
         XCTAssertEqual(result, expected)
@@ -19,6 +20,7 @@ class DirectedGraphTests: XCTestCase {
 
     func testEdgesFromNode() {
         var graph = DirectedGraph<String>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b")
         graph.insertEdge(from: "b", to: "c")
         graph.insertEdge(from: "b", to: "d")

--- a/Tests/DataStructuresTests/GraphTests/GraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/GraphTests.swift
@@ -26,6 +26,7 @@ class GraphTests: XCTestCase {
 
     func testInsertNodes() {
         var result = Graph<Int>()
+        [0,1].forEach { result.insert($0) }
         result.insertEdge(from: 0, to: 1)
         let expected = Graph([0,1], [.init(0,1)])
         XCTAssertEqual(result, expected)
@@ -41,6 +42,7 @@ class GraphTests: XCTestCase {
 
     func testNeighbors() {
         var graph = Graph<String>()
+        ["a","b","c"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b")
         graph.insertEdge(from: "a", to: "c")
         XCTAssertEqual(graph.neighbors(of: "a"), ["b","c"])
@@ -57,6 +59,7 @@ class GraphTests: XCTestCase {
 
     func testBreadthFirstSearch() {
         var graph = Graph<String>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b")
         graph.insertEdge(from: "b", to: "c")
         graph.insertEdge(from: "c", to: "d")

--- a/Tests/DataStructuresTests/GraphTests/WeightedDataGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/WeightedDataGraphTests.swift
@@ -1,0 +1,110 @@
+//
+//  WeightedDataGraphTests.swift
+//  DataStructuresTests
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+import XCTest
+import DataStructures
+
+class WeightedDataGraphTests: XCTestCase {
+    
+    func testInsertNodes() {
+        var result = WeightedDataGraph<String,Int,Double>()
+        ["a":0,"b":1].forEach { result.insert($0, value: $1) }
+        result.insertEdge(from: "a", to: "b", weight: 42.0)
+        let expected = WeightedDataGraph(["a":0,"b":1], [.init("b","a"): 42.0])
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testWeightForEdge() {
+        var graph = WeightedDataGraph<String,Int,Int>()
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        XCTAssertNil(graph.weight(UnorderedPair("c","e")))
+        XCTAssertEqual(graph.weight(UnorderedPair("b","c")), 7)
+        XCTAssertEqual(graph.weight(from: "d", to: "e"), 13)
+    }
+    
+    func testUpdateEdge() {
+        var graph = WeightedDataGraph<String,Int,Int>()
+        graph.insertEdge(from: "a", to: "b", weight: 1)
+        graph.updateEdge(from: "a", to: "b") { $0 * 2 }
+        XCTAssertEqual(graph.weight(from: "a", to: "b"), 2)
+    }
+    
+    func testContains() {
+        var graph = WeightedDataGraph<String,Int,Int>()
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        XCTAssertFalse(graph.contains(UnorderedPair("a","c")))
+        XCTAssert(graph.contains(UnorderedPair("b","d")))
+    }
+    
+    func testNeighbors() {
+        var graph = WeightedDataGraph<String,String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0, value: $0) }
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        XCTAssertEqual(graph.neighbors(of: "b"), ["a","c","d"])
+        XCTAssertEqual(graph.neighbors(of: "f"), [])
+    }
+    
+    func testRemoveEdge() {
+        var graph = WeightedDataGraph<String,Int,Int>()
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        graph.removeEdge(from: "b", to: "d")
+        XCTAssertFalse(graph.contains(UnorderedPair("b","d")))
+    }
+    
+    func testUnweightedFromUndirected() {
+        var graph = WeightedDataGraph<String,Int,Int>()
+        ["a":0,"b":1,"c":2,"d":3,"e":4].forEach { graph.insert($0, value: $1) }
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        let unweighted: DataGraph<String, Int> = graph.unweighted()
+        let expected = DataGraph(
+            ["a":0,"b":1,"c":2,"d":3,"e":4],
+            [
+                UnorderedPair("a","b"),
+                UnorderedPair("b","c"),
+                UnorderedPair("b","d"),
+                UnorderedPair("d","e")
+            ]
+        )
+        XCTAssertEqual(unweighted, expected)
+    }
+    
+    func testUnweightedFromDirected() {
+        var graph = WeightedDirectedDataGraph<String,Int,Int>()
+        ["a":0,"b":0,"c":0,"d":0,"e":0].forEach { graph.insert($0, value: $1) }
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        let unweighted: DirectedDataGraph<String,Int> = graph.unweighted()
+        let expected: DirectedDataGraph<String,Int> = DirectedDataGraph(
+            ["a":0,"b":0,"c":0,"d":0,"e":0],
+            [
+                OrderedPair("a","b"),
+                OrderedPair("b","c"),
+                OrderedPair("b","d"),
+                OrderedPair("d","e")
+            ]
+        )
+        XCTAssertEqual(unweighted, expected)
+    }
+}
+

--- a/Tests/DataStructuresTests/GraphTests/WeightedDirectedDataGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/WeightedDirectedDataGraphTests.swift
@@ -1,0 +1,43 @@
+//
+//  WeightedDirectedDataGraphTests.swift
+//  DataStructuresTests
+//
+//  Created by Benjamin Wetherfield on 15/10/2018.
+//
+
+import XCTest
+import DataStructures
+
+class WeightedDirectedDataGraphTests: XCTestCase {
+    
+    func testWeightedDirectedDataGraphInsertNodes() {
+        var result = WeightedDirectedDataGraph<String,Int,Double>()
+        ["Zero":0,"One":1].forEach { result.insert($0, value: $1) }
+        result.insertEdge(from: "Zero", to: "One", weight: 42.0)
+        let expected = WeightedDirectedDataGraph(["Zero":0,"One":1], [.init("Zero","One"): 42.0])
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testEdgesFromNode() {
+        var graph = WeightedDirectedDataGraph<String,String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0, value: $0) }
+        graph.insertEdge(from: "a", to: "b", weight: 5)
+        graph.insertEdge(from: "b", to: "c", weight: 7)
+        graph.insertEdge(from: "b", to: "d", weight: 11)
+        graph.insertEdge(from: "d", to: "e", weight: 13)
+        XCTAssertEqual(graph.edges(from: "b"), [OrderedPair("b","c"),OrderedPair("b","d")])
+    }
+    
+    func testShortestPathTwoOptions() {
+        var graph = WeightedDirectedDataGraph<String, Int, Double>()
+        graph.insert("s", value: 0)
+        graph.insert("a", value: 1)
+        graph.insert("b", value: 0)
+        graph.insert("t", value: 1)
+        graph.insertEdge(from: "s", to: "a", weight: 2.0)
+        graph.insertEdge(from: "s", to: "b", weight: 1.0)
+        graph.insertEdge(from: "a", to: "t", weight: 3.0)
+        graph.insertEdge(from: "b", to: "t", weight: 4.0)
+        XCTAssertEqual(graph.shortestUnweightedPath(from: "s", to: "t")!.count, 3)
+    }
+}

--- a/Tests/DataStructuresTests/GraphTests/WeightedDirectedGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/WeightedDirectedGraphTests.swift
@@ -12,6 +12,7 @@ class WeightedDirectedGraphTests: XCTestCase {
 
     func testWeightedDirectedGraphInsertNodes() {
         var result = WeightedDirectedGraph<String,Double>()
+        ["Zero","One"].forEach { result.insert($0) }
         result.insertEdge(from: "Zero", to: "One", weight: 42.0)
         let expected = WeightedDirectedGraph(["Zero","One"], [.init("Zero","One"): 42.0])
         XCTAssertEqual(result, expected)
@@ -19,6 +20,7 @@ class WeightedDirectedGraphTests: XCTestCase {
 
     func testEdgesFromNode() {
         var graph = WeightedDirectedGraph<String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b", weight: 5)
         graph.insertEdge(from: "b", to: "c", weight: 7)
         graph.insertEdge(from: "b", to: "d", weight: 11)

--- a/Tests/DataStructuresTests/GraphTests/WeightedGraphTests.swift
+++ b/Tests/DataStructuresTests/GraphTests/WeightedGraphTests.swift
@@ -12,6 +12,7 @@ class WeightedGraphTests: XCTestCase {
 
     func testInsertNodes() {
         var result = WeightedGraph<String,Double>()
+        ["a","b"].forEach { result.insert($0) }
         result.insertEdge(from: "a", to: "b", weight: 42.0)
         let expected = WeightedGraph(["a","b"], [.init("b","a"): 42.0])
         XCTAssertEqual(result, expected)
@@ -47,6 +48,7 @@ class WeightedGraphTests: XCTestCase {
 
     func testNeighbors() {
         var graph = WeightedGraph<String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b", weight: 5)
         graph.insertEdge(from: "b", to: "c", weight: 7)
         graph.insertEdge(from: "b", to: "d", weight: 11)
@@ -67,6 +69,7 @@ class WeightedGraphTests: XCTestCase {
 
     func testUnweightedFromUndirected() {
         var graph = WeightedGraph<String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b", weight: 5)
         graph.insertEdge(from: "b", to: "c", weight: 7)
         graph.insertEdge(from: "b", to: "d", weight: 11)
@@ -86,6 +89,7 @@ class WeightedGraphTests: XCTestCase {
 
     func testUnweightedFromDirected() {
         var graph = WeightedDirectedGraph<String,Int>()
+        ["a","b","c","d","e"].forEach { graph.insert($0) }
         graph.insertEdge(from: "a", to: "b", weight: 5)
         graph.insertEdge(from: "b", to: "c", weight: 7)
         graph.insertEdge(from: "b", to: "d", weight: 11)


### PR DESCRIPTION
This PR implements a `Node`-analog to weighted graph implementations, namely graphs where each node is assigned a piece of data. A system of protocols and structs mirror those of the ordinary graphs but with this added data carrying feature. 

The PR is motivated by various use cases in the `PitchSpeller` modules, where we want 
* a graph structure where nodes are not only labeled but also carry `Pitch` values
* a graph structure where nodes are assigned a `Tendency` value

In the above cases and in other usage, the data carrying graph types will give us O(1) lookups of data associated with the nodes thanks to the dictionary storage of the data.