### PR TITLE
Implement Cross Comparable conformance

### DIFF
--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -29,5 +29,12 @@ extension Cross {
     }
 }
 
+extension Cross: Comparable where T: Comparable & Equatable, U: Comparable {
+    
+    public static func < (lhs: Cross, rhs: Cross) -> Bool {
+        return lhs.a < rhs.a || (lhs.a == rhs.a && lhs.b < rhs.b)
+    }
+}
+
 extension Cross: Equatable where T: Equatable, U: Equatable { }
 extension Cross: Hashable where T: Hashable, U: Hashable { }

--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -31,6 +31,9 @@ extension Cross {
 
 extension Cross: Comparable where T: Comparable & Equatable, U: Comparable {
     
+    /// - Returns: true if and only if the first element of `lhs` is less than the first element
+    /// of `rhs` OR if those elements are equal and the second element of `lhs` is less than the
+    /// second element of `rhs` (lexicographic ordering).
     public static func < (lhs: Cross, rhs: Cross) -> Bool {
         return lhs.a < rhs.a || (lhs.a == rhs.a && lhs.b < rhs.b)
     }

--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -29,7 +29,7 @@ extension Cross {
     }
 }
 
-extension Cross: Comparable where T: Comparable & Equatable, U: Comparable {
+extension Cross: Comparable where T: Comparable, U: Comparable {
     
     /// - Returns: true if and only if the first element of `lhs` is less than the first element
     /// of `rhs` OR if those elements are equal and the second element of `lhs` is less than the

--- a/Tests/DataStructuresTests/CrossTests.swift
+++ b/Tests/DataStructuresTests/CrossTests.swift
@@ -1,0 +1,33 @@
+//
+//  CrossTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 10/20/18.
+//
+
+import XCTest
+import DataStructures
+
+class CrossTests: XCTestCase {
+
+    func testComparableFalseEqual() {
+        let a = Cross(1,1)
+        let b = Cross(1,1)
+        XCTAssertEqual(a,b)
+        XCTAssertFalse(a < b)
+    }
+
+    func testComparableLexicographic() {
+        let a = Cross(1,1)
+        let b = Cross(1,2)
+        XCTAssert(a < b)
+        XCTAssert(b > a)
+    }
+
+    func testComparableLexicographicFalse() {
+        let a = Cross(1,2)
+        let b = Cross(1,1)
+        XCTAssertFalse(a < b)
+        XCTAssertFalse(b > a)
+    }
+}


### PR DESCRIPTION
Implements a lexicographic ordering on the parameters of `Cross` where `.a` carries more weight than `.b`.