### PR TITLE
Add tests for Cross Comparable conformance

### DIFF
--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -29,7 +29,7 @@ extension Cross {
     }
 }
 
-extension Cross: Comparable where T: Comparable & Equatable, U: Comparable {
+extension Cross: Comparable where T: Comparable, U: Comparable {
     
     /// - Returns: true if and only if the first element of `lhs` is less than the first element
     /// of `rhs` OR if those elements are equal and the second element of `lhs` is less than the

--- a/Tests/DataStructuresTests/CrossTests.swift
+++ b/Tests/DataStructuresTests/CrossTests.swift
@@ -1,0 +1,33 @@
+//
+//  CrossTests.swift
+//  DataStructuresTests
+//
+//  Created by James Bean on 10/20/18.
+//
+
+import XCTest
+import DataStructures
+
+class CrossTests: XCTestCase {
+
+    func testComparableFalseEqual() {
+        let a = Cross(1,1)
+        let b = Cross(1,1)
+        XCTAssertEqual(a,b)
+        XCTAssertFalse(a < b)
+    }
+
+    func testComparableLexicographic() {
+        let a = Cross(1,1)
+        let b = Cross(1,2)
+        XCTAssert(a < b)
+        XCTAssert(b > a)
+    }
+
+    func testComparableLexicographicFalse() {
+        let a = Cross(1,2)
+        let b = Cross(1,1)
+        XCTAssertFalse(a < b)
+        XCTAssertFalse(b > a)
+    }
+}


### PR DESCRIPTION
This PR adds a few tests for the `Comparable` conformance of `Cross`.

It also removes a redundant conformance of `T: Equatable`, as `Comparable` implies `Equatable`.