### PR TITLE
Refine *Graph benchmarks, make slight performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - SWIFT_VERSION=4.2
 script:
   - swift package update
-  - swift test
+  - swift test -c release
 after_success: 
   - git clone https://github.com/dn-m/Documentarian && cd Documentarian
   - swift build -c release -Xswiftc -static-stdlib

--- a/Sources/DataStructures/BinaryHeap.swift
+++ b/Sources/DataStructures/BinaryHeap.swift
@@ -50,14 +50,6 @@ public struct BinaryHeap <Element: Hashable, Value: Comparable> {
         }
     }
     
-    /// Propose update of `element` to value `suggestion` (accept if `value(of: element)`
-    /// decreases).
-    internal mutating func suggestDecrease (of element: Element, to suggestion: Value) {
-        if suggestion < value(of: element) {
-            decreaseValue(of: element, to: suggestion)
-        }
-    }
-    
     private func lessAt (_ i: Int, than j: Int) -> Bool {
         return value(at: i) < value(at: j)
     }

--- a/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
+++ b/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
@@ -142,7 +142,7 @@ extension ContiguousSegmentCollection: Fragmentable
     /// A fragment of a `ContiguousSegmentCollection`.
     public struct Fragment {
 
-        struct Item {
+        public struct Item {
 
             var end: Metric {
                 return offset + fragment.length
@@ -161,7 +161,7 @@ extension ContiguousSegmentCollection: Fragmentable
 
         // MARK: - Instance Properties
 
-        /// - Returns:
+        /// - Returns: The offset of the fragment within the context of the whole.
         public var offset: Metric {
             return head?.offset ?? body.first?.0 ?? tail?.offset ?? .zero
         }
@@ -174,7 +174,7 @@ extension ContiguousSegmentCollection: Fragmentable
 
         /// Creates a `ContiguousSegmentCollection.Fragment` with the given pair of fragment items
         /// and the segments in-between.
-        init(
+        public init(
             head: Item? = nil,
             body: ContiguousSegmentCollection = .empty,
             tail: Item? = nil

--- a/Sources/DataStructures/Graph/DirectedGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedGraph.swift
@@ -54,6 +54,13 @@ extension DirectedGraph {
         self.nodes = Set(path)
         self.edges = Set(nodes.pairs.map(OrderedPair.init))
     }
+
+    /// Creates a `DirectedGraph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.edges = Set(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension DirectedGraph: Equatable { }

--- a/Sources/DataStructures/Graph/Graph.swift
+++ b/Sources/DataStructures/Graph/Graph.swift
@@ -47,6 +47,13 @@ extension Graph {
         self.init(nodes)
         self.edges = edges
     }
+
+    /// Creates a `Graph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.edges = Set(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension Graph: Equatable { }

--- a/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/GraphProtocol.swift
@@ -47,7 +47,7 @@ extension GraphProtocol {
     /// Removes the given `node` and removes all edges that contain it.
     @inlinable
     public mutating func remove(_ node: Node) {
-        nodes.remove(node)
+        guard nodes.remove(node) != nil else { return }
         edges.filter { $0.contains(node) }.forEach { remove($0) }
     }
 
@@ -79,24 +79,29 @@ extension GraphProtocol {
     /// resultant set.
     @inlinable
     public func neighbors(of source: Node, in nodes: Set<Node>? = nil) -> Set<Node> {
+        guard self.nodes.contains(source) else { return [] }
         return (nodes ?? self.nodes).filter { edges.contains(Edge(source,$0)) }
     }
     
     /// - Returns: A set of edges outgoing from the given `source`.
     @inlinable
     public func edges(from source: Node) -> Set<Edge> {
+        guard nodes.contains(source) else { return [] }
         return Set(neighbors(of: source).lazy.map { Edge(source, $0) })
     }
     
     /// - Returns: A set of edges incident to the given `destination`.
     @inlinable
     public func edges(to destination: Node) -> Set<Edge> {
+        guard nodes.contains(destination) else { return [] }
         return Set(nodes.lazy.map { Edge($0, destination) }.filter(edges.contains))
     }
 
     /// - Returns: An array of `Node` values in breadth first order.
+    // TODO: Consider return `[Node]?` or throwing Error if `source` is not in graph.
     @inlinable
     public func breadthFirstSearch(from source: Node, to destination: Node? = nil) -> [Node] {
+        guard nodes.contains(source) else { return [] }
         var visited: [Node] = []
         var queue = Queue<Node>()
         queue.enqueue(source)
@@ -118,6 +123,7 @@ extension GraphProtocol {
     /// `destination`, the path with the fewest edges is returned.
     @inlinable
     public func shortestUnweightedPath(from source: Node, to destination: Node) -> [Node]? {
+        guard nodes.contains(source) && nodes.contains(destination) else { return nil }
         var breadcrumbs: [Node: Node] = [:]
         func backtrace() -> [Node] {
             var path = [destination]

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -88,7 +88,7 @@ extension WeightedGraphProtocol {
         from source: Node,
         to destination: Node,
         by transform: (Weight) -> Weight
-        )
+    )
     {
         updateEdge(Edge(source,destination), by: transform)
     }

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -42,8 +42,14 @@ extension WeightedDirectedGraph {
         self.init(nodes)
         self.weights = weights
     }
+
+    /// Creates a `WeightedDirectedGraph` with enough memory to store the given
+    /// `minimumNodesCapacity` and `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.weights = Dictionary(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension WeightedDirectedGraph: Equatable { }
 extension WeightedDirectedGraph: Hashable where Weight: Hashable { }
-

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -50,6 +50,13 @@ extension WeightedGraph {
         self.init(nodes)
         self.weights = weights
     }
+
+    /// Creates a `WeightedGraph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.weights = Dictionary(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension WeightedGraph: Equatable { }

--- a/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
+++ b/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
@@ -12,12 +12,13 @@ import PerformanceTesting
 
 class StableSortPerformanceTests: XCTestCase {
 
-    func testStableSort() {
+    // FIXME: There is currently no linearithmic option for `Complexity`.
+    func testStableSort_O_nlogn() {
         let benchmark = Benchmark.mutating(
             testPoints: Scale.small,
             setup: { Array((0..<$0).map { Int.random(in: 0...$0) }) },
             measuring: { _ = $0.stableSort(<) }
         )
-        XCTAssert(benchmark.performance(is: .linear))
+        XCTAssert(benchmark.performance(is: .quadratic))
     }
 }

--- a/Tests/AlgorithmsPerformanceTests/XCTestManifests.swift
+++ b/Tests/AlgorithmsPerformanceTests/XCTestManifests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 extension StableSortPerformanceTests {
     static let __allTests = [
-        ("testStableSort", testStableSort),
+        ("testStableSort", testStableSort_O_nlogn),
     ]
 }
 

--- a/Tests/AlgorithmsTests/CombinatoricsTests.swift
+++ b/Tests/AlgorithmsTests/CombinatoricsTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Algorithms
+import Algorithms
 
 class CombinatoricsTests: XCTestCase {
 

--- a/Tests/AlgorithmsTests/OrderedTests.swift
+++ b/Tests/AlgorithmsTests/OrderedTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import Algorithms
+import Algorithms
 
 class OrderedTests: XCTestCase {
 

--- a/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
@@ -34,13 +34,61 @@ class GraphPerformanceTests: XCTestCase {
         XCTAssert(benchmark.performance(is: .constant))
     }
 
-    func testNeighborsOfNode_O_n() {
+    func testEdgesFromSourceInGraph_O_n() {
         let benchmark = Benchmark.mutating(
-            testPoints: Scale.small,
             setup: graph(size:),
-            measuring: { _ = $0.neighbors(of: Int.random(in: .min ..< .max)) }
+            measuring: { _ = $0.edges(from: 0) }
+        )
+        XCTAssert(benchmark.performance(is: .linear))
+    }
+
+    func testEdgesFromSourceNotInGraph_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: graph(size:),
+            measuring: { _ = $0.edges(from: -1) }
         )
         XCTAssert(benchmark.performance(is: .constant))
+    }
+
+    func testEdgeFromSourceInCompleteGraph_O_n() {
+        let benchmark = Benchmark.mutating(
+            testPoints: Scale.small,
+            setup: completeGraph(size:),
+            measuring: { _ = $0.edges(from: 0) }
+        )
+        XCTAssert(benchmark.performance(is: .linear))
+    }
+
+    func testEdgesToDestinationInGraph_O_n() {
+        let benchmark = Benchmark.mutating(
+            setup: graph(size:),
+            measuring: { _ = $0.edges(from: 0) }
+        )
+        XCTAssert(benchmark.performance(is: .linear))
+    }
+
+    func testEdgesToDestinationNotInGraph_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: graph(size:),
+            measuring: { _ = $0.edges(from: -1) }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
+    }
+
+    func testNeighborsOfNodeNotInGraph_O_1() {
+        let benchmark = Benchmark.mutating(
+            setup: graph(size:),
+            measuring: { _ = $0.neighbors(of: -1) }
+        )
+        XCTAssert(benchmark.performance(is: .constant))
+    }
+
+    func testNeighborsOfNodeInGraph_O_n() {
+        let benchmark = Benchmark.mutating(
+            setup: graph(size:),
+            measuring: { _ = $0.neighbors(of: 0) }
+        )
+        XCTAssert(benchmark.performance(is: .linear))
     }
 
     func testProfile() {
@@ -48,11 +96,23 @@ class GraphPerformanceTests: XCTestCase {
     }
 }
 
-private func graph (size: Int) -> Graph<Int> {
-    var result = Graph<Int>()
-    (0..<size).forEach { size in result.insert(size) }
-    (0..<size/10).forEach { size in
-        _ = result.insertEdge(from: Int.random(in: .min ..< size), to: Int.random(in: .min ..< size))
+private func completeGraph(size: Int) -> Graph<Int> {
+    var graph = Graph<Int>()
+    (0..<size).forEach { size in graph.insert(size) }
+    for a in 0..<size {
+        for b in 0..<size where a != b {
+            graph.insertEdge(from: a, to: b)
+        }
     }
-    return result
+    return graph
+}
+
+/// Creates a `Graph` with nodes from `0..<size`, with roughly 1-in-10 connected to each other
+private func graph(size: Int) -> Graph<Int> {
+    var graph = Graph<Int>()
+    (0..<size).forEach { size in graph.insert(size) }
+    (0..<size/10).forEach { size in
+        _ = graph.insertEdge(from: Int.random(in: 0 ..< size), to: Int.random(in: 0 ..< size))
+    }
+    return graph
 }

--- a/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
@@ -112,7 +112,7 @@ private func graph(size: Int) -> Graph<Int> {
     var graph = Graph<Int>()
     (0..<size).forEach { size in graph.insert(size) }
     (0..<size/10).forEach { size in
-        _ = graph.insertEdge(from: Int.random(in: 0 ..< size), to: Int.random(in: 0 ..< size))
+        _ = graph.insertEdge(from: Int.random(in: 0 ... size), to: Int.random(in: 0 ... size))
     }
     return graph
 }

--- a/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
@@ -97,7 +97,7 @@ class GraphPerformanceTests: XCTestCase {
 }
 
 private func completeGraph(size: Int) -> Graph<Int> {
-    var graph = Graph<Int>()
+    var graph = Graph<Int>(minimumNodesCapacity: size, minimumEdgesCapacity: size * (size - 1) / 2)
     (0..<size).forEach { size in graph.insert(size) }
     for a in 0..<size {
         for b in 0..<size where a != b {

--- a/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
+++ b/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
@@ -18,7 +18,7 @@ extension GraphPerformanceTests {
     static let __allTests = [
         ("testInsertEdge_O_1", testInsertEdge_O_1),
         ("testInsertNode_O_1", testInsertNode_O_1),
-        ("testNeighborsOfNode_O_n", testNeighborsOfNode_O_n),
+        ("testNeighborsOfNode_O_n", testNeighborsOfNodeInGraph_O_n),
     ]
 }
 

--- a/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
+++ b/Tests/DataStructuresPerformanceTests/XCTestManifests.swift
@@ -16,9 +16,16 @@ extension DirectedGraphPerformanceTests {
 
 extension GraphPerformanceTests {
     static let __allTests = [
+        ("testEdgeFromSourceInCompleteGraph_O_n", testEdgeFromSourceInCompleteGraph_O_n),
+        ("testEdgesFromSourceInGraph_O_n", testEdgesFromSourceInGraph_O_n),
+        ("testEdgesFromSourceNotInGraph_O_1", testEdgesFromSourceNotInGraph_O_1),
+        ("testEdgesToDestinationInGraph_O_n", testEdgesToDestinationInGraph_O_n),
+        ("testEdgesToDestinationNotInGraph_O_1", testEdgesToDestinationNotInGraph_O_1),
         ("testInsertEdge_O_1", testInsertEdge_O_1),
         ("testInsertNode_O_1", testInsertNode_O_1),
-        ("testNeighborsOfNode_O_n", testNeighborsOfNodeInGraph_O_n),
+        ("testNeighborsOfNodeInGraph_O_n", testNeighborsOfNodeInGraph_O_n),
+        ("testNeighborsOfNodeNotInGraph_O_1", testNeighborsOfNodeNotInGraph_O_1),
+        ("testProfile", testProfile),
     ]
 }
 
@@ -53,7 +60,6 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(QueuePerformanceTests.__allTests),
         testCase(WeightedDirectedGraphPerformanceTests.__allTests),
         testCase(WeightedGraphPerformanceTests.__allTests),
-        testCase(QueuePerformanceTests.__allTests),
     ]
 }
 #endif

--- a/Tests/DataStructuresTests/AVLTreeTests.swift
+++ b/Tests/DataStructuresTests/AVLTreeTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import DataStructures
+import DataStructures
 
 class AVLTreeTests: XCTestCase {
 

--- a/Tests/DataStructuresTests/BinaryHeapTests.swift
+++ b/Tests/DataStructuresTests/BinaryHeapTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import DataStructures
+import DataStructures
 
 class BinaryHeapTests: XCTestCase {
     
@@ -42,18 +42,6 @@ class BinaryHeapTests: XCTestCase {
         input.enumerated().forEach { pair in heap.insert(pair.0, pair.1) }
         let output = (0..<100).map { _ in heap.pop()!.1 }
         let testAgainst = input.sorted()
-        XCTAssertEqual(testAgainst, output)
-        XCTAssertNil(heap.pop())
-    }
-    
-    func testUpdate() {
-        var heap = BinaryHeap<Int, Double>()
-        let input = (0..<100).map { _ in Double.random(in: 0...1) }
-        let throughput = (0..<100).map { _ in Double.random(in: 0...1) }
-        let testAgainst = (0..<100).map { i in min(input[i], throughput[i]) }.sorted()
-        input.enumerated().forEach { pair in heap.insert(pair.0, pair.1) }
-        throughput.enumerated().forEach { pair in heap.suggestDecrease(of: pair.0, to: pair.1) }
-        let output = (0..<100).map { _ in heap.pop()!.1 }
         XCTAssertEqual(testAgainst, output)
         XCTAssertNil(heap.pop())
     }

--- a/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
+++ b/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import DataStructures
+import DataStructures
 
 extension Int: IntervallicFragmentable {
     public struct Fragment: Intervallic {

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -51,8 +51,7 @@ extension BinaryHeapTests {
         ("testBalance", testBalance),
         ("testBasicInsertPop", testBasicInsertPop),
         ("testPopNil", testPopNil),
-        ("testSimpleBalance", testSimpleBalance),
-        ("testUpdate", testUpdate),
+        ("testSimpleBalance", testSimpleBalance)
     ]
 }
 

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -104,6 +104,14 @@ extension ContiguousSegmentCollectionTests {
     ]
 }
 
+extension CrossTests {
+    static let __allTests = [
+        ("testComparableFalseEqual", testComparableFalseEqual),
+        ("testComparableLexicographic", testComparableLexicographic),
+        ("testComparableLexicographicFalse", testComparableLexicographicFalse),
+    ]
+}
+
 extension DictionaryProtocolsTests {
     static let __allTests = [
         ("testDictionaryInitWithArrayOfTuples", testDictionaryInitWithArrayOfTuples),
@@ -500,6 +508,17 @@ extension TreeTests {
     ]
 }
 
+extension UnorderedPairTests {
+    static let __allTests = [
+        ("testEquatable", testEquatable),
+        ("testHashValuesInt", testHashValuesInt),
+        ("testHashValuesString", testHashValuesString),
+        ("testManyHashValuesIntForCollisions", testManyHashValuesIntForCollisions),
+        ("testManyHashValuesString", testManyHashValuesString),
+        ("testManyHashValuesStringForCollisions", testManyHashValuesStringForCollisions),
+    ]
+}
+
 extension WeightedDirectedGraphTests {
     static let __allTests = [
         ("testEdgesFromNode", testEdgesFromNode),
@@ -547,6 +566,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(BinarySearchTreeTests.__allTests),
         testCase(CircularArrayTests.__allTests),
         testCase(ContiguousSegmentCollectionTests.__allTests),
+        testCase(CrossTests.__allTests),
         testCase(DictionaryProtocolsTests.__allTests),
         testCase(DirectedGraphTests.__allTests),
         testCase(EitherTests.__allTests),
@@ -569,6 +589,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(StackTests.__allTests),
         testCase(SubsetsTests.__allTests),
         testCase(TreeTests.__allTests),
+        testCase(UnorderedPairTests.__allTests),
         testCase(WeightedDirectedGraphTests.__allTests),
         testCase(WeightedGraphTests.__allTests),
         testCase(Zip3SequenceTests.__allTests),


### PR DESCRIPTION
This PR adds and fixes a few `Graph` ecosystem performance benchmarks.

@bwetherfield, in cases where `neighbors(of:)` is called with a node which is not present in the `Graph`, this now exits early. This takes this function from always O(*n*) to always O(1) in the case of a non-existent node.

We _were_ talking about throwing an `Error` for these cases instead. That may be a better long term solution, but this will improve things for now.