### PR TITLE
Add *Graph.init with minimum capacities for nodes and edges

### DIFF
--- a/Sources/DataStructures/Graph/DirectedGraph.swift
+++ b/Sources/DataStructures/Graph/DirectedGraph.swift
@@ -54,6 +54,13 @@ extension DirectedGraph {
         self.nodes = Set(path)
         self.edges = Set(nodes.pairs.map(OrderedPair.init))
     }
+
+    /// Creates a `DirectedGraph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.edges = Set(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension DirectedGraph: Equatable { }

--- a/Sources/DataStructures/Graph/Graph.swift
+++ b/Sources/DataStructures/Graph/Graph.swift
@@ -47,6 +47,13 @@ extension Graph {
         self.init(nodes)
         self.edges = edges
     }
+
+    /// Creates a `Graph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.edges = Set(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension Graph: Equatable { }

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -88,7 +88,7 @@ extension WeightedGraphProtocol {
         from source: Node,
         to destination: Node,
         by transform: (Weight) -> Weight
-        )
+    )
     {
         updateEdge(Edge(source,destination), by: transform)
     }

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -42,8 +42,14 @@ extension WeightedDirectedGraph {
         self.init(nodes)
         self.weights = weights
     }
+
+    /// Creates a `WeightedDirectedGraph` with enough memory to store the given
+    /// `minimumNodesCapacity` and `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.weights = Dictionary(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension WeightedDirectedGraph: Equatable { }
 extension WeightedDirectedGraph: Hashable where Weight: Hashable { }
-

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -50,6 +50,13 @@ extension WeightedGraph {
         self.init(nodes)
         self.weights = weights
     }
+
+    /// Creates a `WeightedGraph` with enough memory to store the given `minimumNodesCapacity` and
+    /// `minimumEdgesCapacity`.
+    public init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int) {
+        self.nodes = Set(minimumCapacity: minimumNodesCapacity)
+        self.weights = Dictionary(minimumCapacity: minimumEdgesCapacity)
+    }
 }
 
 extension WeightedGraph: Equatable { }

--- a/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
+++ b/Tests/DataStructuresPerformanceTests/GraphPerformanceTests/GraphPerformanceTests.swift
@@ -97,7 +97,7 @@ class GraphPerformanceTests: XCTestCase {
 }
 
 private func completeGraph(size: Int) -> Graph<Int> {
-    var graph = Graph<Int>()
+    var graph = Graph<Int>(minimumNodesCapacity: size, minimumEdgesCapacity: size * (size - 1) / 2)
     (0..<size).forEach { size in graph.insert(size) }
     for a in 0..<size {
         for b in 0..<size where a != b {
@@ -112,7 +112,7 @@ private func graph(size: Int) -> Graph<Int> {
     var graph = Graph<Int>()
     (0..<size).forEach { size in graph.insert(size) }
     (0..<size/10).forEach { size in
-        _ = graph.insertEdge(from: Int.random(in: 0 ..< size), to: Int.random(in: 0 ..< size))
+        _ = graph.insertEdge(from: Int.random(in: 0 ... size), to: Int.random(in: 0 ... size))
     }
     return graph
 }


### PR DESCRIPTION
This PR adds `.init(minimumNodesCapacity: Int, minimumEdgesCapacity: Int)`  to all of the `*Graph` types.

This will be helpful for the pitch spelling `FlowNetwork` (which is nearly (if not) a complete graph). As such, we can construct the directed graph with a nodes capacity of `pitches.count` and edges capacity of ca. `pitches.count * (pitches.count - 1) / 2` (we could get more specific).

This seems to give a performance boost of ~20+%.