### PR TITLE
Make assertion less incorrect for stable sort performance test

### DIFF
--- a/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
+++ b/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
@@ -12,12 +12,12 @@ import PerformanceTesting
 
 class StableSortPerformanceTests: XCTestCase {
 
-    func testStableSort() {
+    func testStableSort_O_nlogn() {
         let benchmark = Benchmark.mutating(
             testPoints: Scale.small,
             setup: { Array((0..<$0).map { Int.random(in: 0...$0) }) },
             measuring: { _ = $0.stableSort(<) }
         )
-        XCTAssert(benchmark.performance(is: .linear))
+        XCTAssert(benchmark.performance(is: .quadratic))
     }
 }

--- a/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
+++ b/Tests/AlgorithmsPerformanceTests/StableSortPerformanceTests.swift
@@ -12,6 +12,7 @@ import PerformanceTesting
 
 class StableSortPerformanceTests: XCTestCase {
 
+    // FIXME: There is currently no linearithmic option for `Complexity`.
     func testStableSort_O_nlogn() {
         let benchmark = Benchmark.mutating(
             testPoints: Scale.small,

--- a/Tests/AlgorithmsPerformanceTests/XCTestManifests.swift
+++ b/Tests/AlgorithmsPerformanceTests/XCTestManifests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 extension StableSortPerformanceTests {
     static let __allTests = [
-        ("testStableSort", testStableSort),
+        ("testStableSort", testStableSort_O_nlogn),
     ]
 }
 


### PR DESCRIPTION
The `StableSortPerformanceTests` has been failing randomly. This is for good reason. It was being asserted that it should be done in `.linear` time, however, it should really be O(*n* log *n*) AKA linearithmic.

For now, `.quadratic` will do.