### PR TITLE
[Proposal] Remove conformance conditions from Weight

### DIFF
--- a/Sources/Algebra/AdditiveGroup.swift
+++ b/Sources/Algebra/AdditiveGroup.swift
@@ -5,7 +5,7 @@
 //  Created by Benjamin Wetherfield on 10/11/2018.
 //
 
-protocol AdditiveGroup: Additive, Invertible {
+public protocol AdditiveGroup: Additive, Invertible {
     
     static prefix func - (_ element: Self) -> Self
     static func - (lhs: Self, rhs: Self) -> Self

--- a/Sources/Algebra/AdditiveGroup.swift
+++ b/Sources/Algebra/AdditiveGroup.swift
@@ -1,0 +1,23 @@
+//
+//  AdditiveGroup.swift
+//  Algebra
+//
+//  Created by Benjamin Wetherfield on 10/11/2018.
+//
+
+protocol AdditiveGroup: Additive, Invertible {
+    
+    static prefix func - (_ element: Self) -> Self
+    static func - (lhs: Self, rhs: Self) -> Self
+}
+
+extension AdditiveGroup {
+    
+    static prefix func - (_ element: Self) -> Self {
+        return element.inverse
+    }
+    
+    static func - (lhs: Self, rhs: Self) -> Self {
+        return lhs + -rhs
+    }
+}

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -5,13 +5,15 @@
 //  Created by James Bean on 9/27/18.
 //
 
+import Algebra
+
 /// Interface for weighted graphs.
 public protocol WeightedGraphProtocol: GraphProtocol {
 
     // MARK: - Associated Type
 
     /// The type of the weight of an `Edge`.
-    associatedtype Weight: Numeric
+    associatedtype Weight: AdditiveGroup
 
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
+++ b/Sources/DataStructures/Graph/Protocols/WeightedGraphProtocol.swift
@@ -13,7 +13,7 @@ public protocol WeightedGraphProtocol: GraphProtocol {
     // MARK: - Associated Type
 
     /// The type of the weight of an `Edge`.
-    associatedtype Weight: AdditiveGroup
+    associatedtype Weight
 
     // MARK: - Instance Properties
 

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -7,7 +7,7 @@
 import Algebra
 
 /// Weighted, directed graph.
-public struct WeightedDirectedGraph <Node: Hashable, Weight: AdditiveGroup & Equatable>:
+public struct WeightedDirectedGraph <Node: Hashable, Weight>:
     WeightedGraphProtocol,
     DirectedGraphProtocol
 {
@@ -45,6 +45,6 @@ extension WeightedDirectedGraph {
     }
 }
 
-extension WeightedDirectedGraph: Equatable { }
+extension WeightedDirectedGraph: Equatable where Weight: Equatable { }
 extension WeightedDirectedGraph: Hashable where Weight: Hashable { }
 

--- a/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedDirectedGraph.swift
@@ -4,9 +4,10 @@
 //
 //  Created by James Bean on 9/27/18.
 //
+import Algebra
 
 /// Weighted, directed graph.
-public struct WeightedDirectedGraph <Node: Hashable, Weight: Numeric>:
+public struct WeightedDirectedGraph <Node: Hashable, Weight: AdditiveGroup & Equatable>:
     WeightedGraphProtocol,
     DirectedGraphProtocol
 {

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -7,7 +7,7 @@
 import Algebra
 
 /// Weighted, undirected graph.
-public struct WeightedGraph <Node: Hashable, Weight: AdditiveGroup & Equatable>:
+public struct WeightedGraph <Node: Hashable, Weight>:
     WeightedGraphProtocol,
     UndirectedGraphProtocol
 {
@@ -20,7 +20,7 @@ public struct WeightedGraph <Node: Hashable, Weight: AdditiveGroup & Equatable>:
 
     /// All of the edges contained herein stored with their weight.
     ///
-    /// An `Edge` is an `UnorderedPair` of `Node` values, and a `Weight` is any `Numeric`-conforming
+    /// An `Edge` is an `UnorderedPair` of `Node` values, and a `Weight` is any `AdditiveGroup`-conforming
     /// value.
     public var weights: [Edge: Weight]
 }
@@ -53,5 +53,5 @@ extension WeightedGraph {
     }
 }
 
-extension WeightedGraph: Equatable { }
+extension WeightedGraph: Equatable where Weight: Equatable { }
 extension WeightedGraph: Hashable where Weight: Hashable { }

--- a/Sources/DataStructures/Graph/WeightedGraph.swift
+++ b/Sources/DataStructures/Graph/WeightedGraph.swift
@@ -4,9 +4,10 @@
 //
 //  Created by James Bean on 9/27/18.
 //
+import Algebra
 
 /// Weighted, undirected graph.
-public struct WeightedGraph <Node: Hashable, Weight: Numeric>:
+public struct WeightedGraph <Node: Hashable, Weight: AdditiveGroup & Equatable>:
     WeightedGraphProtocol,
     UndirectedGraphProtocol
 {


### PR DESCRIPTION
Two options here:

(1) [see second commit] Let `Weight` conform to `AdditiveGroup` (which is a superset of `Numeric`), since we never need to multiply edges.

(2) [see third commit] Let `Weight` be free of conformance, since we don't actually define any numerical operations in these protocols... It is `FlowNetwork` downstream that requires `AdditiveGroup` conformance (as well as `Comparable` conformance).

In any case, `AdditiveGroup` will be useful to define for use in `FlowNetwork` in the `NotationModel` repository.