### PR TITLE
Fix tail offset of ContiguousSegmentCollection.fragment(in:)

### DIFF
--- a/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
+++ b/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
@@ -212,8 +212,8 @@ extension ContiguousSegmentCollection: Fragmentable where
 
         public init(body: ContiguousSegmentCollection<Segment>, tail: Segment.Fragment) {
             precondition(!body.isEmpty)
-            let offset = body.first!.0
-            let tail = Item(offset: offset - tail.length, fragment: tail)
+            let offset = body.first!.0 + body.length
+            let tail = Item(offset: offset, fragment: tail)
             self.init(body: body, tail: tail)
         }
 
@@ -228,7 +228,7 @@ extension ContiguousSegmentCollection: Fragmentable where
         /// fragments, offset by the given `offset`.
         public init(_ head: Segment.Fragment, _ tail: Segment.Fragment, offset: Metric = .zero) {
             let head = Item(offset: offset, fragment: head)
-            let tail = Item(offset: offset + tail.length, fragment: tail)
+            let tail = Item(offset: head.end, fragment: tail)
             self.init(head: head, tail: tail)
         }
     }

--- a/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
+++ b/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
@@ -210,7 +210,7 @@ class ContiguousSegmentCollectionTests: XCTestCase {
 
     ///                x  x
     /// |--||---------||--|
-    func testFragmnetOfFragmentTailTail() {
+    func testFragmentOfFragmentTailTail() {
         let fragment = collection.fragment(in: 1 ..< 14)
         let subfragment = fragment.fragment(in: 12 ..< 14)
         let single = Int.Fragment(4, in: 0..<2)

--- a/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
+++ b/Tests/DataStructuresTests/ContiguousSegmentCollectionTests.swift
@@ -78,6 +78,7 @@ class ContiguousSegmentCollectionTests: XCTestCase {
         let single = Int.Fragment(4, in: 1..<3)
         let expected = ContiguousSegmentCollection<Int>.Fragment(single, offset: 9)
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 9)
     }
 
     ///         x x
@@ -87,6 +88,7 @@ class ContiguousSegmentCollectionTests: XCTestCase {
         let single = Int.Fragment(4, in: 0..<2)
         let expected = ContiguousSegmentCollection<Int>.Fragment(single, offset: 8)
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 8)
     }
 
     ///           x x
@@ -96,6 +98,7 @@ class ContiguousSegmentCollectionTests: XCTestCase {
         let single = Int.Fragment(4, in: 2..<4)
         let expected = ContiguousSegmentCollection<Int>.Fragment(single, offset: 10)
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 10)
     }
 
     ///         x   x
@@ -105,6 +108,7 @@ class ContiguousSegmentCollectionTests: XCTestCase {
         let body = ContiguousSegmentCollection([4], offset: 8)
         let expected = ContiguousSegmentCollection<Int>.Fragment(body: body)
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 8)
     }
 
     ///     x     x
@@ -116,6 +120,8 @@ class ContiguousSegmentCollectionTests: XCTestCase {
             tail: Int.Fragment(4, in: 0..<2)
         )
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 4)
+        XCTAssertEqual(fragment.last!.0, 8)
     }
 
     ///       x     x
@@ -127,6 +133,8 @@ class ContiguousSegmentCollectionTests: XCTestCase {
             body: ContiguousSegmentCollection([4], offset: 8)
         )
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 6)
+        XCTAssertEqual(fragment.last!.0, 8)
     }
 
     ///   x             x
@@ -138,6 +146,8 @@ class ContiguousSegmentCollectionTests: XCTestCase {
             body: ContiguousSegmentCollection<Int>([4,4,4], offset: 4)
         )
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 2)
+        XCTAssertEqual(fragment.last!.0, 12)
     }
 
     /// x             x
@@ -149,6 +159,8 @@ class ContiguousSegmentCollectionTests: XCTestCase {
             tail: Int.Fragment(4, in: 0..<2)
         )
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 0)
+        XCTAssertEqual(fragment.last!.0, 12)
     }
 
     /// x               x
@@ -157,6 +169,8 @@ class ContiguousSegmentCollectionTests: XCTestCase {
         let fragment = collection.fragment(in: 0..<16)
         let expected = ContiguousSegmentCollection<Int>.Fragment(body: [4,4,4,4])
         XCTAssertEqual(fragment, expected)
+        XCTAssertEqual(fragment.first!.0, 0)
+        XCTAssertEqual(fragment.last!.0, 12)
     }
 
     // MARK: ContiguousSegment.Fragment

--- a/Tests/DataStructuresTests/XCTestManifests.swift
+++ b/Tests/DataStructuresTests/XCTestManifests.swift
@@ -97,7 +97,7 @@ extension ContiguousSegmentCollectionTests {
         ("testFragmentOfFragmentBodyTail", testFragmentOfFragmentBodyTail),
         ("testFragmentOfFragmentHeadBody", testFragmentOfFragmentHeadBody),
         ("testFragmentOfFragmentHeadHead", testFragmentOfFragmentHeadHead),
-        ("testFragmnetOfFragmentTailTail", testFragmnetOfFragmentTailTail),
+        ("testFragmentOfFragmentTailTail", testFragmentOfFragmentTailTail),
         ("testInitSegments", testInitSegments),
         ("testLength", testLength),
         ("testOffsets", testOffsets),


### PR DESCRIPTION
This PR fixes a bug in `ContiguousSegmentCollection.fragment(in:)` where the offset of a `tail` `Item` is set incorrectly.