### PR TITLE
Add Codable Conformance to Pair types, replace deprecated usage

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "PerformanceTesting",
         "repositoryURL": "https://github.com/dn-m/PerformanceTesting",
         "state": {
-          "branch": null,
-          "revision": "d48417c837b1a029dd9567dfa7b5ee3cfa9a0ec7",
-          "version": "0.3.0"
+          "branch": "pitchspeller-dependency",
+          "revision": "fd97209b9465e698c51cb30dfc24db35f39fa5c5",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Algorithms", targets: ["Algorithms"])
     ],
     dependencies: [
-        .package(url: "https://github.com/dn-m/PerformanceTesting", from: "0.2.0")
+        .package(url: "https://github.com/dn-m/PerformanceTesting", .branch("pitchspeller-dependency"))
     ],
     targets: [
 

--- a/Sources/DataStructures/InvertibleEnum.swift
+++ b/Sources/DataStructures/InvertibleEnum.swift
@@ -14,7 +14,7 @@ public protocol InvertibleEnum: CaseIterable, Equatable {
 extension InvertibleEnum where AllCases.Index == Int {
     /// - Returns: Inverse of `self`.
     public var inverse: Self {
-        let index = Self.allCases.index(of: self)!
+        let index = Self.allCases.firstIndex(of: self)!
         let inverseIndex = Self.allCases.count - (1 + index)
         return Self.allCases[inverseIndex]
     }

--- a/Sources/DataStructures/Metatype.swift
+++ b/Sources/DataStructures/Metatype.swift
@@ -43,6 +43,6 @@ extension Metatype: Hashable {
     /// - Returns: A unique hash value for the metatype wrapped-up herein.
     @inlinable
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(base).hashValue)
+        hasher.combine(ObjectIdentifier(base))
     }
 }

--- a/Sources/DataStructures/NewType.swift
+++ b/Sources/DataStructures/NewType.swift
@@ -24,8 +24,9 @@ extension NewType where Value: Equatable {
 }
 
 extension NewType where Value: Hashable {
-    public var hashValue: Int {
-        return value.hashValue
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
     }
 }
 

--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -41,6 +41,7 @@ extension Cross: Comparable where T: Comparable, U: Comparable {
 
 extension Cross: Equatable where T: Equatable, U: Equatable { }
 extension Cross: Hashable where T: Hashable, U: Hashable { }
+extension Cross: Codable where T: Codable, U: Codable { }
 
 extension Cross: CustomStringConvertible {
 

--- a/Sources/DataStructures/Pair/OrderedPair.swift
+++ b/Sources/DataStructures/Pair/OrderedPair.swift
@@ -28,6 +28,7 @@ public struct OrderedPair <T>: SwappablePair {
 
 extension OrderedPair: Equatable where T: Equatable { }
 extension OrderedPair: Hashable where T: Hashable { }
+extension OrderedPair: Codable where T: Codable { }
 
 extension OrderedPair: CustomStringConvertible {
 

--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -59,6 +59,8 @@ extension UnorderedPair: Hashable where T: Hashable {
     }
 }
 
+extension UnorderedPair: Codable where T: Codable { }
+
 extension UnorderedPair: CustomStringConvertible {
 
     // MARK: - CustomStringConvertible

--- a/Sources/DataStructures/ReferenceTree.swift
+++ b/Sources/DataStructures/ReferenceTree.swift
@@ -160,7 +160,7 @@ public class ReferenceTree {
      */
     public func removeChild(_ node: ReferenceTree) throws {
 
-        guard let index = children.index(where: { $0 === node }) else {
+        guard let index = children.firstIndex(where: { $0 === node }) else {
             throw Error.nodeNotFound
         }
 

--- a/Sources/DataStructures/ReferenceTreeProtocol.swift
+++ b/Sources/DataStructures/ReferenceTreeProtocol.swift
@@ -139,7 +139,7 @@ public extension ReferenceTreeProtocol {
     /// - throws: `ReferenceTreeError.removalError` if the given `node` is not held in `children`.
     func removeChild(_ node: Self) throws {
 
-        guard let index = children.index(where: { $0 === node }) else {
+        guard let index = children.firstIndex(where: { $0 === node }) else {
             throw ReferenceTreeError.nodeNotFound
         }
 

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -62,7 +62,7 @@ public struct SortedArray <Element: Comparable>:
     ///
     /// - TODO: Make `throws` instead of returning silently.
     public mutating func remove(_ element: Element) {
-        guard let index = base.index(of: element) else { return }
+        guard let index = base.firstIndex(of: element) else { return }
         base.remove(at: index)
     }
 

--- a/Sources/DataStructures/Wrapping/DoubleWrapping.swift
+++ b/Sources/DataStructures/Wrapping/DoubleWrapping.swift
@@ -31,7 +31,9 @@ extension DoubleWrapping {
 
     // MARK: - Hashable
 
-    public var hashValue: Int { return value.hashValue }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
 }
 
 // MARK: - Comparable

--- a/Sources/DataStructures/Wrapping/FloatWrapping.swift
+++ b/Sources/DataStructures/Wrapping/FloatWrapping.swift
@@ -32,7 +32,9 @@ extension FloatWrapping {
 
     // MARK: - Hashable
 
-    public var hashValue: Int { return value.hashValue }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
 }
 
 // MARK: - Comparable

--- a/Sources/DataStructures/Wrapping/IntegerWrapping.swift
+++ b/Sources/DataStructures/Wrapping/IntegerWrapping.swift
@@ -35,8 +35,8 @@ extension IntegerWrapping {
 
     // MARK: - Hashable
 
-    public var hashValue: Int {
-        return value.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
     }
 }
 


### PR DESCRIPTION
As needed for [bwetherfield/PitchSpeller](https://github.com/bwetherfield/PitchSpeller)