### PR TITLE
Add default Codable conformance to DataStructures

### DIFF
--- a/Sources/DataStructures/AVLTree.swift
+++ b/Sources/DataStructures/AVLTree.swift
@@ -205,8 +205,6 @@ extension AVLTree.Node: Equatable where Value: Equatable {
     }
 }
 
-extension AVLTree: Equatable where Value: Equatable { }
-
 extension AVLTree: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
@@ -216,3 +214,5 @@ extension AVLTree: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+extension AVLTree: Equatable where Value: Equatable { }

--- a/Sources/DataStructures/AVLTree.swift
+++ b/Sources/DataStructures/AVLTree.swift
@@ -222,5 +222,8 @@ extension AVLTree.Node: Hashable where Key: Hashable, Value: Hashable {
     }
 }
 
+extension AVLTree.Node: Codable where Key: Codable, Value: Codable { }
+
 extension AVLTree: Equatable where Value: Equatable { }
 extension AVLTree: Hashable where Key: Hashable, Value: Hashable { }
+extension AVLTree: Codable where Key: Codable, Value: Codable { }

--- a/Sources/DataStructures/AVLTree.swift
+++ b/Sources/DataStructures/AVLTree.swift
@@ -215,4 +215,12 @@ extension AVLTree: ExpressibleByArrayLiteral {
     }
 }
 
+extension AVLTree.Node: Hashable where Key: Hashable, Value: Hashable {
+    /// Uses the `ObjectIdentifier` of this `Node` to determine hashing.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+}
+
 extension AVLTree: Equatable where Value: Equatable { }
+extension AVLTree: Hashable where Key: Hashable, Value: Hashable { }

--- a/Sources/DataStructures/AdjacencyList.swift
+++ b/Sources/DataStructures/AdjacencyList.swift
@@ -166,3 +166,4 @@ extension AdjacencyList {
 
 extension AdjacencyList: Equatable { }
 extension AdjacencyList: Hashable { }
+extension AdjacencyList: Codable where Node: Codable { }

--- a/Sources/DataStructures/AdjacencyList.swift
+++ b/Sources/DataStructures/AdjacencyList.swift
@@ -163,3 +163,6 @@ extension AdjacencyList {
         return flag
     }
 }
+
+extension AdjacencyList: Equatable { }
+extension AdjacencyList: Hashable { }

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -7,7 +7,7 @@
 
 /// Dictionary-like structure which allows O(1) access from `Key` to `Value` as well as from `Value`
 /// to `Key`.
-public struct Bimap <Key: Hashable, Value: Hashable>: Hashable {
+public struct Bimap <Key: Hashable, Value: Hashable> {
 
     // MARK: - Instance Properties
 
@@ -236,3 +236,5 @@ extension Bimap {
     }
 }
 
+extension Bimap: Equatable { }
+extension Bimap: Hashable { }

--- a/Sources/DataStructures/Bimap.swift
+++ b/Sources/DataStructures/Bimap.swift
@@ -238,3 +238,4 @@ extension Bimap {
 
 extension Bimap: Equatable { }
 extension Bimap: Hashable { }
+extension Bimap: Codable where Key: Codable, Value: Codable { }

--- a/Sources/DataStructures/BinaryHeap.swift
+++ b/Sources/DataStructures/BinaryHeap.swift
@@ -129,3 +129,4 @@ public struct BinaryHeap <Element: Hashable, Value: Comparable> {
 
 extension BinaryHeap: Equatable { }
 extension BinaryHeap: Hashable where Value: Hashable { }
+extension BinaryHeap: Codable where Element: Codable, Value: Codable { }

--- a/Sources/DataStructures/BinaryHeap.swift
+++ b/Sources/DataStructures/BinaryHeap.swift
@@ -126,3 +126,6 @@ public struct BinaryHeap <Element: Hashable, Value: Comparable> {
         bubbleDown(from: 0)
     }
 }
+
+extension BinaryHeap: Equatable { }
+extension BinaryHeap: Hashable where Value: Hashable { }

--- a/Sources/DataStructures/BinarySearchTree.swift
+++ b/Sources/DataStructures/BinarySearchTree.swift
@@ -155,3 +155,5 @@ extension BinarySearchTree: ExpressibleByArrayLiteral {
 
 extension BinarySearchTree: Equatable { }
 extension BinarySearchTree: Hashable where Value: Hashable { }
+
+// TODO: `Codable`

--- a/Sources/DataStructures/BinarySearchTree.swift
+++ b/Sources/DataStructures/BinarySearchTree.swift
@@ -152,3 +152,6 @@ extension BinarySearchTree: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+extension BinarySearchTree: Equatable { }
+extension BinarySearchTree: Hashable where Value: Hashable { }

--- a/Sources/DataStructures/CircularArray.swift
+++ b/Sources/DataStructures/CircularArray.swift
@@ -167,8 +167,6 @@ extension CircularArray: RangeReplaceableCollection {
     }
 }
 
-extension CircularArray: Equatable where Element: Equatable { }
-
 extension CircularArray: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
@@ -192,3 +190,6 @@ extension Array {
         return CircularArray(self)
     }
 }
+
+extension CircularArray: Equatable where Element: Equatable { }
+extension CircularArray: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/CircularArray.swift
+++ b/Sources/DataStructures/CircularArray.swift
@@ -193,3 +193,4 @@ extension Array {
 
 extension CircularArray: Equatable where Element: Equatable { }
 extension CircularArray: Hashable where Element: Hashable { }
+extension CircularArray: Codable where Element: Codable { }

--- a/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
+++ b/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
@@ -506,9 +506,6 @@ extension ContiguousSegmentCollection.Fragment.Item: Equatable where
 extension ContiguousSegmentCollection.Fragment: Equatable where
     Segment: Equatable, Segment.Fragment: Equatable { }
 
-extension ContiguousSegmentCollection: Equatable where Segment: Equatable { }
-extension ContiguousSegmentCollection: Hashable where Segment: Hashable { }
-
 extension ContiguousSegmentCollection: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
@@ -527,3 +524,6 @@ extension ContiguousSegmentCollection: CustomStringConvertible {
         return map { offset,segment in  "\(offset): \(segment)" }.joined(separator: "\n")
     }
 }
+
+extension ContiguousSegmentCollection: Equatable where Segment: Equatable { }
+extension ContiguousSegmentCollection: Hashable where Segment: Hashable { }

--- a/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
+++ b/Sources/DataStructures/ContiguousSegmentCollection/ContiguousSegmentCollection.swift
@@ -527,3 +527,4 @@ extension ContiguousSegmentCollection: CustomStringConvertible {
 
 extension ContiguousSegmentCollection: Equatable where Segment: Equatable { }
 extension ContiguousSegmentCollection: Hashable where Segment: Hashable { }
+extension ContiguousSegmentCollection: Codable where Metric: Codable, Segment: Codable { }

--- a/Sources/DataStructures/Either.swift
+++ b/Sources/DataStructures/Either.swift
@@ -45,5 +45,38 @@ public enum Either <Left,Right> {
     }
 }
 
+extension Either: Codable where Left: Codable, Right: Codable {
+
+    enum DecodingError: Error {
+        case invalidCase
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case left
+        case right
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let value = try? container.decode(Left.self, forKey: .left) {
+            self = .left(value)
+        } else if let value = try? container.decode(Right.self, forKey: .right) {
+            self = .right(value)
+        } else {
+            throw DecodingError.invalidCase
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .left(value):
+            try container.encode(value, forKey: .left)
+        case let .right(value):
+            try container.encode(value, forKey: .right)
+        }
+    }
+}
+
 extension Either: Equatable where Left: Equatable, Right: Equatable { }
 extension Either: Hashable where Left: Hashable, Right: Hashable { }

--- a/Sources/DataStructures/Either.swift
+++ b/Sources/DataStructures/Either.swift
@@ -46,3 +46,4 @@ public enum Either <Left,Right> {
 }
 
 extension Either: Equatable where Left: Equatable, Right: Equatable { }
+extension Either: Hashable where Left: Hashable, Right: Hashable { }

--- a/Sources/DataStructures/Identifier.swift
+++ b/Sources/DataStructures/Identifier.swift
@@ -19,7 +19,6 @@
 ///     truck == friend
 ///     // Binary operator '==' cannot be applied to operands of type 'Identifier<Truck>' and
 ///     // 'Identifier<Friend>'
-///
 public struct Identifier <Subject> {
 
     let value: Int

--- a/Sources/DataStructures/IntervalRelation.swift
+++ b/Sources/DataStructures/IntervalRelation.swift
@@ -161,3 +161,6 @@ extension RangeProtocol {
         return value > lowerBound && value < upperBound
     }
 }
+
+extension IntervalRelation: Equatable { }
+extension IntervalRelation: Hashable { }

--- a/Sources/DataStructures/IntervalRelation.swift
+++ b/Sources/DataStructures/IntervalRelation.swift
@@ -24,7 +24,7 @@
 /// [Allen](https://en.wikipedia.org/wiki/James_F._Allen), refined by
 /// [Krokhin et al.](http://www.ics.uci.edu/~alspaugh/cls/shr/allen.html#Allen1983-mkti).
 ///
-public enum IntervalRelation: InvertibleEnum {
+public enum IntervalRelation: String, InvertibleEnum {
 
     // MARK: - Cases
 
@@ -164,3 +164,4 @@ extension RangeProtocol {
 
 extension IntervalRelation: Equatable { }
 extension IntervalRelation: Hashable { }
+extension IntervalRelation: Codable { }

--- a/Sources/DataStructures/LinkedList.swift
+++ b/Sources/DataStructures/LinkedList.swift
@@ -86,8 +86,6 @@ extension LinkedList: Collection {
     }
 }
 
-extension LinkedList: Equatable where Element: Equatable { }
-
 extension LinkedList: ExpressibleByArrayLiteral {
 
     // - MARK: ExpressibleByArrayLiteral
@@ -100,3 +98,6 @@ extension LinkedList: ExpressibleByArrayLiteral {
             .reduce(.end) { $0.cons(value: $1) }
     }
 }
+
+extension LinkedList: Equatable where Element: Equatable { }
+extension LinkedList: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/LinkedList.swift
+++ b/Sources/DataStructures/LinkedList.swift
@@ -101,3 +101,5 @@ extension LinkedList: ExpressibleByArrayLiteral {
 
 extension LinkedList: Equatable where Element: Equatable { }
 extension LinkedList: Hashable where Element: Hashable { }
+
+// TODO: Codable

--- a/Sources/DataStructures/Matrix.swift
+++ b/Sources/DataStructures/Matrix.swift
@@ -119,8 +119,6 @@ extension Matrix: SequenceWrapping {
     }
 }
 
-extension Matrix: Equatable where Element: Equatable { }
-
 extension Matrix: CustomStringConvertible {
 
     // MARK: - CustomStringConvertible
@@ -155,3 +153,6 @@ extension Matrix: CustomStringConvertible {
         return rows.map(format).joined(separator: "\n")
     }
 }
+
+extension Matrix: Equatable where Element: Equatable { }
+extension Matrix: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/Matrix.swift
+++ b/Sources/DataStructures/Matrix.swift
@@ -156,3 +156,4 @@ extension Matrix: CustomStringConvertible {
 
 extension Matrix: Equatable where Element: Equatable { }
 extension Matrix: Hashable where Element: Hashable { }
+extension Matrix: Codable where Element: Codable { }

--- a/Sources/DataStructures/OrderedDictionary.swift
+++ b/Sources/DataStructures/OrderedDictionary.swift
@@ -134,3 +134,4 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
 
 extension OrderedDictionary: Equatable where Value: Equatable { }
 extension OrderedDictionary: Hashable where Value: Hashable { }
+extension OrderedDictionary: Codable where Key: Codable, Value: Codable { }

--- a/Sources/DataStructures/OrderedDictionary.swift
+++ b/Sources/DataStructures/OrderedDictionary.swift
@@ -121,9 +121,6 @@ extension OrderedDictionary: Collection {
     }
 }
 
-extension OrderedDictionary: Equatable where Value: Equatable { }
-extension OrderedDictionary: Hashable where Value: Hashable { }
-
 extension OrderedDictionary: ExpressibleByDictionaryLiteral {
 
     // MARK: - ExpressibleByDictionaryLiteral
@@ -134,3 +131,6 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
         elements.forEach { (k, v) in append(v, key: k) }
     }
 }
+
+extension OrderedDictionary: Equatable where Value: Equatable { }
+extension OrderedDictionary: Hashable where Value: Hashable { }

--- a/Sources/DataStructures/Pair/Cross.swift
+++ b/Sources/DataStructures/Pair/Cross.swift
@@ -39,10 +39,6 @@ extension Cross: Comparable where T: Comparable, U: Comparable {
     }
 }
 
-extension Cross: Equatable where T: Equatable, U: Equatable { }
-extension Cross: Hashable where T: Hashable, U: Hashable { }
-extension Cross: Codable where T: Codable, U: Codable { }
-
 extension Cross: CustomStringConvertible {
 
     // MARK: - CustomStringConvertible
@@ -52,3 +48,7 @@ extension Cross: CustomStringConvertible {
         return "<\(a),\(b)>"
     }
 }
+
+extension Cross: Equatable where T: Equatable, U: Equatable { }
+extension Cross: Hashable where T: Hashable, U: Hashable { }
+extension Cross: Codable where T: Codable, U: Codable { }

--- a/Sources/DataStructures/Pair/OrderedPair.swift
+++ b/Sources/DataStructures/Pair/OrderedPair.swift
@@ -26,10 +26,6 @@ public struct OrderedPair <T>: SwappablePair {
     }
 }
 
-extension OrderedPair: Equatable where T: Equatable { }
-extension OrderedPair: Hashable where T: Hashable { }
-extension OrderedPair: Codable where T: Codable { }
-
 extension OrderedPair: CustomStringConvertible {
 
     // MARK: - CustomStringConvertible
@@ -39,3 +35,7 @@ extension OrderedPair: CustomStringConvertible {
         return "(\(a),\(b))"
     }
 }
+
+extension OrderedPair: Equatable where T: Equatable { }
+extension OrderedPair: Hashable where T: Hashable { }
+extension OrderedPair: Codable where T: Codable { }

--- a/Sources/DataStructures/Pair/UnorderedPair.swift
+++ b/Sources/DataStructures/Pair/UnorderedPair.swift
@@ -59,8 +59,6 @@ extension UnorderedPair: Hashable where T: Hashable {
     }
 }
 
-extension UnorderedPair: Codable where T: Codable { }
-
 extension UnorderedPair: CustomStringConvertible {
 
     // MARK: - CustomStringConvertible
@@ -70,3 +68,5 @@ extension UnorderedPair: CustomStringConvertible {
         return "{\(a),\(b)}"
     }
 }
+
+extension UnorderedPair: Codable where T: Codable { }

--- a/Sources/DataStructures/Queue.swift
+++ b/Sources/DataStructures/Queue.swift
@@ -69,3 +69,6 @@ extension Queue {
         return storage.removeFirst()
     }
 }
+
+extension Queue: Equatable where Element: Equatable { }
+extension Queue: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/Queue.swift
+++ b/Sources/DataStructures/Queue.swift
@@ -72,3 +72,4 @@ extension Queue {
 
 extension Queue: Equatable where Element: Equatable { }
 extension Queue: Hashable where Element: Hashable { }
+extension Queue: Codable where Element: Codable { }

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -172,3 +172,4 @@ extension SortedArray: ExpressibleByArrayLiteral {
 
 extension SortedArray: Equatable { }
 extension SortedArray: Hashable where Element: Hashable { }
+extension SortedArray: Codable where Element: Codable { }

--- a/Sources/DataStructures/SortedArray.swift
+++ b/Sources/DataStructures/SortedArray.swift
@@ -118,9 +118,6 @@ public struct SortedArray <Element: Comparable>:
     }
 }
 
-extension SortedArray: Equatable { }
-extension SortedArray: Hashable where Element: Hashable { }
-
 extension SortedArray {
 
     /// - Returns: The slice of the `SortedArray` for the given `bounds`.
@@ -172,3 +169,6 @@ extension SortedArray: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+extension SortedArray: Equatable { }
+extension SortedArray: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/SortedDictionary.swift
+++ b/Sources/DataStructures/SortedDictionary.swift
@@ -184,9 +184,6 @@ extension SortedDictionary {
     }
 }
 
-extension SortedDictionary: Equatable where Value: Equatable { }
-extension SortedDictionary: Hashable where Value: Hashable { }
-
 extension SortedDictionary: ExpressibleByDictionaryLiteral {
 
     // MARK: - ExpressibleByDictionaryLiteral
@@ -205,3 +202,6 @@ extension SortedDictionary: Zero {
         return .init()
     }
 }
+
+extension SortedDictionary: Equatable where Value: Equatable { }
+extension SortedDictionary: Hashable where Value: Hashable { }

--- a/Sources/DataStructures/SortedDictionary.swift
+++ b/Sources/DataStructures/SortedDictionary.swift
@@ -205,3 +205,4 @@ extension SortedDictionary: Zero {
 
 extension SortedDictionary: Equatable where Value: Equatable { }
 extension SortedDictionary: Hashable where Value: Hashable { }
+extension SortedDictionary: Codable where Key: Codable, Value: Codable { }

--- a/Sources/DataStructures/Stack.swift
+++ b/Sources/DataStructures/Stack.swift
@@ -168,3 +168,4 @@ extension Stack: Monoid {
 
 extension Stack: Equatable where Element: Equatable { }
 extension Stack: Hashable where Element: Hashable { }
+extension Stack: Codable where Element: Codable { }

--- a/Sources/DataStructures/Stack.swift
+++ b/Sources/DataStructures/Stack.swift
@@ -116,14 +116,6 @@ extension Stack: BidirectionalCollection {
     }
 }
 
-extension Stack: Equatable where Element: Equatable {
-
-    /// - returns: `true` if two `Stack` values are equivalent. Otherwise `false`.
-    public static func == (lhs: Stack, rhs: Stack) -> Bool {
-        return lhs.elements == rhs.elements
-    }
-}
-
 extension Stack: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
@@ -173,3 +165,6 @@ extension Stack: Monoid {
         return lhs + rhs
     }
 }
+
+extension Stack: Equatable where Element: Equatable { }
+extension Stack: Hashable where Element: Hashable { }

--- a/Sources/DataStructures/Tree.swift
+++ b/Sources/DataStructures/Tree.swift
@@ -368,3 +368,5 @@ public func zip <T,U,V> (_ a: Tree<T,T>, _ b: Tree<U,U>, _ f: (T, U) -> V) -> Tr
 
 extension Tree: Equatable where Leaf: Equatable, Branch: Equatable { }
 extension Tree: Hashable where Leaf: Hashable, Branch: Hashable { }
+
+// TODO: Codable


### PR DESCRIPTION
Enum types except for `Either` were left out for now.